### PR TITLE
fix(search): fix parse error when using an empty string

### DIFF
--- a/api/src/queries/SearchQuery.js
+++ b/api/src/queries/SearchQuery.js
@@ -18,8 +18,14 @@ class SearchQuery {
   }
 
   _generateSubStringClause () {
+    // empty substring
+    if (!this.params.substring) {
+      return '/.*/'
+    }
+
     // prepare search substring
     let subStringClause = `${this.params.substring.replace(/[^A-Za-z0-9]/g, ' ')}~`
+
     if (subStringClause.includes(' ')) {
       subStringClause = `'${subStringClause}'`
     }


### PR DESCRIPTION
When searching using an empty string (initial search), the result was a Lucene parsing error. 

Example query:

```gql
query {
        searchResults: searchMetadataText(substring: "", onTypes: [DigitalDocument]) {
            ... on DigitalDocument {
                identifier
                title
                description
                contributor
                thumbnailUrl
            }
        }
}
```