### PR TITLE
feat(project): allow querying ControlAction by target property

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1557,7 +1557,7 @@
     },
     "@types/accepts": {
       "version": "1.3.5",
-      "resolved": "http://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
       "requires": {
         "@types/node": "*"
@@ -2510,7 +2510,7 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
@@ -3675,7 +3675,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
@@ -4418,7 +4418,7 @@
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
@@ -4431,7 +4431,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -4466,7 +4466,7 @@
       "dependencies": {
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         }
@@ -4574,7 +4574,7 @@
     },
     "has-symbols": {
       "version": "1.0.0",
-      "resolved": "https://neo.jfrog.io/neo/api/npm/npm/has-symbols/-/has-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "has-value": {
@@ -7729,7 +7729,7 @@
     },
     "retry": {
       "version": "0.12.0",
-      "resolved": "https://neo.jfrog.io/neo/api/npm/npm/retry/-/retry-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "rimraf": {
@@ -7946,7 +7946,7 @@
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
@@ -8444,7 +8444,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
@@ -8468,7 +8468,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "https://neo.jfrog.io/neo/api/npm/npm/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
     },
     "text-table": {

--- a/api/src/driver.js
+++ b/api/src/driver.js
@@ -9,6 +9,6 @@ export const driver = neo4j.driver(
   process.env.NEO4J_URI || 'bolt://localhost:7687',
   neo4j.auth.basic(
     process.env.NEO4J_USER || 'neo4j',
-    process.env.NEO4J_PASSWORD || 'neo4j'
+    process.env.NEO4J_PASSWORD || 'letmein'
   )
 )

--- a/api/src/queries/GetControlActionByTargetQuery.js
+++ b/api/src/queries/GetControlActionByTargetQuery.js
@@ -20,7 +20,7 @@ class GetControlActionByTargetQuery {
     const alias = StringHelper.lowercaseFirstCharacter(this.resolveInfo.fieldName)
 
     // split the params into targetParams and baseParams
-    const { target: targetParams, ...baseParams } = this.params
+    const { targetIdentifier, ...baseParams } = this.params
 
     // compose query string
     return [
@@ -29,7 +29,7 @@ class GetControlActionByTargetQuery {
       `})`,
       this.queryHelper.generateRelationClause(this.baseType, 'target'),
       `(\`entryPoint\`:\`EntryPoint\` {`,
-      this.queryHelper.generateConditionalClause(targetParams),
+      this.queryHelper.generateConditionalClause({ identifier: targetIdentifier }),
       `})`,
       `WITH \`${alias}\`, HEAD(labels(\`${alias}\`)) as _schemaType`,
       `RETURN \`${alias}\` {`,

--- a/api/src/queries/GetControlActionByTargetQuery.js
+++ b/api/src/queries/GetControlActionByTargetQuery.js
@@ -1,0 +1,44 @@
+import StringHelper from '../helpers/StringHelper'
+import QueryHelper from '../helpers/QueryHelper'
+
+class GetControlActionByTargetQuery {
+  constructor (params, resolveInfo) {
+    this.params = params
+    this.resolveInfo = resolveInfo
+
+    this.queryHelper = new QueryHelper()
+    this.baseNode = this.resolveInfo.fieldNodes[0]
+    this.baseType = this.baseNode.name.value
+  }
+
+  get query () {
+    return this._generateQuery()
+  }
+
+  _generateQuery () {
+    // retrieve constants from parameters
+    const alias = StringHelper.lowercaseFirstCharacter(this.resolveInfo.fieldName)
+
+    // split the params into targetParams and baseParams
+    const { target: targetParams, ...baseParams } = this.params
+
+    // compose query string
+    return [
+      `MATCH (\`${alias}\`:\`${this.baseType}\` {`,
+      this.queryHelper.generateConditionalClause(baseParams),
+      `})`,
+      this.queryHelper.generateRelationClause(this.baseType, 'target'),
+      `(\`entryPoint\`:\`EntryPoint\` {`,
+      this.queryHelper.generateConditionalClause(targetParams),
+      `})`,
+      `WITH \`${alias}\`, HEAD(labels(\`${alias}\`)) as _schemaType`,
+      `RETURN \`${alias}\` {`,
+      this.queryHelper.selectedPropertiesClause(this.baseType, alias, this.baseNode.selectionSet),
+      `}`,
+      `AS \`${alias}\``,
+      this.queryHelper.generatePaginationClause(this.params)
+    ].join(` `)
+  }
+}
+
+export default GetControlActionByTargetQuery

--- a/api/src/resolvers/query.js
+++ b/api/src/resolvers/query.js
@@ -14,7 +14,7 @@ export const queryResolvers = {
       return getQuery(params, resolveInfo)
     },
     ControlAction (object, params, context, resolveInfo) {
-      return getQuery(params, resolveInfo, params.target ? GetControlActionByTargetQuery : GetQuery)
+      return getQuery(params, resolveInfo, params.targetIdentifier ? GetControlActionByTargetQuery : GetQuery)
     },
     Person (object, params, context, resolveInfo) {
       return getQuery(params, resolveInfo)

--- a/api/src/resolvers/query.js
+++ b/api/src/resolvers/query.js
@@ -1,6 +1,7 @@
 import { info } from '../index'
 import { driver } from '../driver'
 import { retrieveNodeData, hydrateNodeSearchScore } from '../resolvers'
+import GetControlActionByTargetQuery from '../queries/GetControlActionByTargetQuery';
 import GetQuery from '../queries/GetQuery'
 import SearchQuery from '../queries/SearchQuery'
 
@@ -13,7 +14,7 @@ export const queryResolvers = {
       return getQuery(params, resolveInfo)
     },
     ControlAction (object, params, context, resolveInfo) {
-      return getQuery(params, resolveInfo)
+      return getQuery(params, resolveInfo, params.target ? GetControlActionByTargetQuery : GetQuery)
     },
     Person (object, params, context, resolveInfo) {
       return getQuery(params, resolveInfo)
@@ -106,8 +107,8 @@ export const queryResolvers = {
   }
 }
 
-const getQuery = function (params, resolveInfo) {
-  const queryGenerator = new GetQuery(params, resolveInfo)
+const getQuery = function (params, resolveInfo, QueryBuilder = GetQuery) {
+  const queryGenerator = new QueryBuilder(params, resolveInfo)
   const query = queryGenerator.query
   info(`query: ${query}`)
 

--- a/api/src/schema/input.graphql
+++ b/api/src/schema/input.graphql
@@ -71,3 +71,7 @@ input _PropertyInput {
   nodeIdentifier: String!
   nodeType: ValueType!
 }
+
+input _TargetInput {
+  identifier: String
+}

--- a/api/src/schema/input.graphql
+++ b/api/src/schema/input.graphql
@@ -71,7 +71,3 @@ input _PropertyInput {
   nodeIdentifier: String!
   nodeType: ValueType!
 }
-
-input _TargetInput {
-  identifier: String
-}

--- a/api/src/schema/query.graphql
+++ b/api/src/schema/query.graphql
@@ -1,7 +1,7 @@
 type Query {
   personBySubstring(substring: String!): [Person] @cypher(statement: "MATCH (p:Person) WHERE p.name CONTAINS $substring RETURN p")
   searchMetadataText(substring: String!, onFields: [SearchableMetadataFields], onTypes: [MetadataInterfaceType], offset: Int = 0, first: Int = 0): [MetadataInterfaced]
-  ControlAction(identifier: String, offset: Int, first: Int): [ControlAction]
+  ControlAction(identifier: String, target: _TargetInput, offset: Int, first: Int): [ControlAction]
   Person(identifier: String, title: String, creator: String, contributor: String, source: URL, language: AvailableLanguage, publisher: String, offset: Int, first: Int):[Person]
   CreativeWork(identifier: String, title: String, creator: String, contributor: String, source: URL, language: AvailableLanguage, publisher: String, offset: Int, first: Int):[CreativeWork]
   Article(identifier: String, title: String, creator: String, contributor: String, source: URL, language: AvailableLanguage, publisher: String, offset: Int, first: Int):[Article]

--- a/api/src/schema/query.graphql
+++ b/api/src/schema/query.graphql
@@ -1,7 +1,7 @@
 type Query {
   personBySubstring(substring: String!): [Person] @cypher(statement: "MATCH (p:Person) WHERE p.name CONTAINS $substring RETURN p")
   searchMetadataText(substring: String!, onFields: [SearchableMetadataFields], onTypes: [MetadataInterfaceType], offset: Int = 0, first: Int = 0): [MetadataInterfaced]
-  ControlAction(identifier: String, target: _TargetInput, offset: Int, first: Int): [ControlAction]
+  ControlAction(identifier: String, targetIdentifier: String, offset: Int, first: Int): [ControlAction]
   Person(identifier: String, title: String, creator: String, contributor: String, source: URL, language: AvailableLanguage, publisher: String, offset: Int, first: Int):[Person]
   CreativeWork(identifier: String, title: String, creator: String, contributor: String, source: URL, language: AvailableLanguage, publisher: String, offset: Int, first: Int):[CreativeWork]
   Article(identifier: String, title: String, creator: String, contributor: String, source: URL, language: AvailableLanguage, publisher: String, offset: Int, first: Int):[Article]


### PR DESCRIPTION
This pull request adds the possibility to query for ControlActions with a given target. This is useful to be able to get all ControlActions that originate from a given EntryPoint. Which can be used by algorithms that use a polling processing mechanism.

```gql
query {
  ControlAction(
    target: { identifier: "d7a3b614-4c40-413f-99d6-c0da2c844963" }
  ) {
    __typename
    identifier
    description
    actionStatus
  }
}
``` 

**TODO:** 

- [ ] @wimklerkx to be discussed; `targetIdentifier: "id"` VS `target: { identifier: "id" }` 
- [ ] Create an abstract class for the GetQuery and GetControlActionByTargetQuery classes.