### PR TITLE
Feat/improve linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+/data
+/img
+/neo4j
+
+node_modules

--- a/api/src/resolvers/query.js
+++ b/api/src/resolvers/query.js
@@ -1,7 +1,7 @@
 import { info } from '../index'
 import { driver } from '../driver'
 import { retrieveNodeData, hydrateNodeSearchScore } from '../resolvers'
-import GetControlActionByTargetQuery from '../queries/GetControlActionByTargetQuery';
+import GetControlActionByTargetQuery from '../queries/GetControlActionByTargetQuery'
 import GetQuery from '../queries/GetQuery'
 import SearchQuery from '../queries/SearchQuery'
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,9 +4,9 @@ module.exports = {
       '@babel/preset-env',
       {
         targets: {
-          node: 'current',
-        },
-      },
-    ],
-  ],
-};
+          node: 'current'
+        }
+      }
+    ]
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3509,12 +3509,12 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
+      "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
       "dev": true,
       "requires": {
-        "async": "^2.5.0",
+        "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
@@ -4715,9 +4715,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "scripts": {
     "version": "conventional-changelog -i CHANGELOG.md -s && git add -A CHANGELOG.md",
-    "test": "jest tests/helpers.js tests --coverage"
+    "test": "jest tests/helpers.js tests --coverage",
+    "lint": "eslint api tests"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Most important changes:

- ignore node_modules when running eslint.
- add lint command to package scripts. e.g. run `$ npm run lint` or even `$ npm run lint -- --fix`