### PR TITLE
feat(schema): add name param in Person query

### DIFF
--- a/src/schema/query.graphql
+++ b/src/schema/query.graphql
@@ -2,7 +2,7 @@ type Query {
   personBySubstring(substring: String!): [Person] @cypher(statement: "MATCH (p:Person) WHERE p.name CONTAINS $substring RETURN p")
   searchMetadataText(substring: String!, onFields: [SearchableMetadataFields], onTypes: [MetadataInterfaceType], offset: Int = 0, first: Int = 0): [MetadataInterfaced]
   ControlAction(identifier: String, targetIdentifier: String, offset: Int, first: Int): [ControlAction]
-  Person(identifier: String, title: String, creator: String, contributor: String, source: URL, language: AvailableLanguage, publisher: String, offset: Int, first: Int):[Person]
+  Person(identifier: String, title: String, name: String, creator: String, contributor: String, source: URL, language: AvailableLanguage, publisher: String, offset: Int, first: Int):[Person]
   CreativeWork(identifier: String, title: String, creator: String, contributor: String, source: URL, language: AvailableLanguage, publisher: String, offset: Int, first: Int):[CreativeWork]
   Article(identifier: String, title: String, creator: String, contributor: String, source: URL, language: AvailableLanguage, publisher: String, offset: Int, first: Int):[Article]
   DigitalDocument(identifier: String, title: String, creator: String, contributor: String, source: URL, language: AvailableLanguage, publisher: String, offset: Int, first: Int):[DigitalDocument]


### PR DESCRIPTION
Fixes #19

You can now run the following query:

```
query {
   Person (name: "Gustav Mahler") {
    identifier
    name
  }
}
```