### PR TITLE
Make workExample relation the inverse of exampleOfWork

### DIFF
--- a/src/resolvers/mutation.js
+++ b/src/resolvers/mutation.js
@@ -1,4 +1,4 @@
-import { info, warning } from '../index'
+import { info, warning } from '../utils/logger'
 import { driver } from '../driver'
 import { retrieveNodeData, pubsub } from '../resolvers'
 import RequestControlActionCommand from '../commands/RequestControlActionCommand'

--- a/src/schema/enum.graphql
+++ b/src/schema/enum.graphql
@@ -9,6 +9,7 @@ enum ThingInterfaceRelationToThingInterface {
 enum ThingInterfaceRelationToCreativeWorkInterface {
   mainEntityOfPage
   subjectOf
+  exampleOfWork
 }
 
 # TODO auto generate

--- a/src/schema/interface/CreativeWorkInterface.graphql
+++ b/src/schema/interface/CreativeWorkInterface.graphql
@@ -125,8 +125,8 @@ interface CreativeWorkInterface {
   version: String
   "https://schema.org/video"
   video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
-  "https://schema.org/creativeWork"
-  workExample: [CreativeWorkInterfaced] @relation(name: "WORK_EXAMPLE", direction: "OUT")
+  "https://schema.org/workExample"
+  workExample: [CreativeWorkInterfaced] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
   "https://bib.schema.org/workTranslation"
   workTranslation: [CreativeWorkInterfaced] @relation(name: "WORK_TRANSLATION", direction: "OUT")
 }

--- a/src/schema/type/Article.graphql
+++ b/src/schema/type/Article.graphql
@@ -207,8 +207,8 @@ type Article implements MetadataInterface & SearchableInterface & ThingInterface
   version: String
   "https://schema.org/video"
   video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
-  "https://schema.org/creativeWork"
-  workExample: [CreativeWorkInterfaced] @relation(name: "WORK_EXAMPLE", direction: "OUT")
+  "https://schema.org/workExample"
+  workExample: [CreativeWorkInterfaced] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
   "https://bib.schema.org/workTranslation"
   workTranslation: [CreativeWorkInterfaced] @relation(name: "WORK_TRANSLATION", direction: "OUT")
   ##########################

--- a/src/schema/type/AudioObject.graphql
+++ b/src/schema/type/AudioObject.graphql
@@ -207,8 +207,8 @@ type AudioObject implements MetadataInterface & SearchableInterface & ThingInter
   version: String
   "https://schema.org/video"
   video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
-  "https://schema.org/creativeWork"
-  workExample: [CreativeWorkInterfaced] @relation(name: "WORK_EXAMPLE", direction: "OUT")
+  "https://schema.org/workExample"
+  workExample: [CreativeWorkInterfaced] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
   "https://bib.schema.org/workTranslation"
   workTranslation: [CreativeWorkInterfaced] @relation(name: "WORK_TRANSLATION", direction: "OUT")
   #######################################

--- a/src/schema/type/CreativeWork.graphql
+++ b/src/schema/type/CreativeWork.graphql
@@ -207,8 +207,8 @@ type CreativeWork implements MetadataInterface & SearchableInterface & ThingInte
   version: String
   "https://schema.org/video"
   video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
-  "https://schema.org/creativeWork"
-  workExample: [CreativeWorkInterfaced] @relation(name: "WORK_EXAMPLE", direction: "OUT")
+  "https://schema.org/workExample"
+  workExample: [CreativeWorkInterfaced] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
   "https://bib.schema.org/workTranslation"
   workTranslation: [CreativeWorkInterfaced] @relation(name: "WORK_TRANSLATION", direction: "OUT")
 }

--- a/src/schema/type/DataDownload.graphql
+++ b/src/schema/type/DataDownload.graphql
@@ -207,8 +207,8 @@ type DataDownload implements MetadataInterface & SearchableInterface & ThingInte
   version: String
   "https://schema.org/video"
   video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
-  "https://schema.org/creativeWork"
-  workExample: [CreativeWorkInterfaced] @relation(name: "WORK_EXAMPLE", direction: "OUT")
+  "https://schema.org/workExample"
+  workExample: [CreativeWorkInterfaced] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
   "https://bib.schema.org/workTranslation"
   workTranslation: [CreativeWorkInterfaced] @relation(name: "WORK_TRANSLATION", direction: "OUT")
   #######################################

--- a/src/schema/type/Dataset.graphql
+++ b/src/schema/type/Dataset.graphql
@@ -207,8 +207,8 @@ type Dataset implements MetadataInterface & SearchableInterface & ThingInterface
   version: String
   "https://schema.org/video"
   video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
-  "https://schema.org/creativeWork"
-  workExample: [CreativeWorkInterfaced] @relation(name: "WORK_EXAMPLE", direction: "OUT")
+  "https://schema.org/workExample"
+  workExample: [CreativeWorkInterfaced] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
   "https://bib.schema.org/workTranslation"
   workTranslation: [CreativeWorkInterfaced] @relation(name: "WORK_TRANSLATION", direction: "OUT")
   #######################################

--- a/src/schema/type/DigitalDocument.graphql
+++ b/src/schema/type/DigitalDocument.graphql
@@ -207,8 +207,8 @@ type DigitalDocument implements MetadataInterface & SearchableInterface & ThingI
   version: String
   "https://schema.org/video"
   video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
-  "https://schema.org/creativeWork"
-  workExample: [CreativeWorkInterfaced] @relation(name: "WORK_EXAMPLE", direction: "OUT")
+  "https://schema.org/workExample"
+  workExample: [CreativeWorkInterfaced] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
   "https://bib.schema.org/workTranslation"
   workTranslation: [CreativeWorkInterfaced] @relation(name: "WORK_TRANSLATION", direction: "OUT")
   ##########################

--- a/src/schema/type/ImageObject.graphql
+++ b/src/schema/type/ImageObject.graphql
@@ -207,8 +207,8 @@ type ImageObject implements MetadataInterface & SearchableInterface & ThingInter
   version: String
   "https://schema.org/video"
   video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
-  "https://schema.org/creativeWork"
-  workExample: [CreativeWorkInterfaced] @relation(name: "WORK_EXAMPLE", direction: "OUT")
+  "https://schema.org/workExample"
+  workExample: [CreativeWorkInterfaced] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
   "https://bib.schema.org/workTranslation"
   workTranslation: [CreativeWorkInterfaced] @relation(name: "WORK_TRANSLATION", direction: "OUT")
   #######################################

--- a/src/schema/type/MediaObject.graphql
+++ b/src/schema/type/MediaObject.graphql
@@ -207,8 +207,8 @@ type MediaObject implements MetadataInterface & SearchableInterface & ThingInter
   version: String
   "https://schema.org/video"
   video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
-  "https://schema.org/creativeWork"
-  workExample: [CreativeWorkInterfaced] @relation(name: "WORK_EXAMPLE", direction: "OUT")
+  "https://schema.org/workExample"
+  workExample: [CreativeWorkInterfaced] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
   "https://bib.schema.org/workTranslation"
   workTranslation: [CreativeWorkInterfaced] @relation(name: "WORK_TRANSLATION", direction: "OUT")
   #######################################

--- a/src/schema/type/MusicAlbum.graphql
+++ b/src/schema/type/MusicAlbum.graphql
@@ -207,8 +207,8 @@ type MusicAlbum implements MetadataInterface & SearchableInterface & ThingInterf
   version: String
   "https://schema.org/video"
   video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
-  "https://schema.org/creativeWork"
-  workExample: [CreativeWorkInterfaced] @relation(name: "WORK_EXAMPLE", direction: "OUT")
+  "https://schema.org/workExample"
+  workExample: [CreativeWorkInterfaced] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
   "https://bib.schema.org/workTranslation"
   workTranslation: [CreativeWorkInterfaced] @relation(name: "WORK_TRANSLATION", direction: "OUT")
   #######################################

--- a/src/schema/type/MusicComposition.graphql
+++ b/src/schema/type/MusicComposition.graphql
@@ -209,7 +209,7 @@ type MusicComposition implements MetadataInterface & SearchableInterface & Thing
   "https://schema.org/video"
   video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
   "https://schema.org/workExample"
-  workExample: [CreativeWorkInterfaced] @relation(name: "WORK_EXAMPLE", direction: "OUT")
+  workExample: [CreativeWorkInterfaced] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
   "https://bib.schema.org/workTranslation"
   workTranslation: [CreativeWorkInterfaced] @relation(name: "WORK_TRANSLATION", direction: "OUT")
   #######################################

--- a/src/schema/type/MusicPlaylist.graphql
+++ b/src/schema/type/MusicPlaylist.graphql
@@ -207,8 +207,8 @@ type MusicPlaylist implements MetadataInterface & SearchableInterface & ThingInt
   version: String
   "https://schema.org/video"
   video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
-  "https://schema.org/creativeWork"
-  workExample: [CreativeWorkInterfaced] @relation(name: "WORK_EXAMPLE", direction: "OUT")
+  "https://schema.org/workExample"
+  workExample: [CreativeWorkInterfaced] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
   "https://bib.schema.org/workTranslation"
   workTranslation: [CreativeWorkInterfaced] @relation(name: "WORK_TRANSLATION", direction: "OUT")
   #######################################

--- a/src/schema/type/MusicRecording.graphql
+++ b/src/schema/type/MusicRecording.graphql
@@ -207,8 +207,8 @@ type MusicRecording implements MetadataInterface & SearchableInterface & ThingIn
   version: String
   "https://schema.org/video"
   video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
-  "https://schema.org/creativeWork"
-  workExample: [CreativeWorkInterfaced] @relation(name: "WORK_EXAMPLE", direction: "OUT")
+  "https://schema.org/workExample"
+  workExample: [CreativeWorkInterfaced] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
   "https://bib.schema.org/workTranslation"
   workTranslation: [CreativeWorkInterfaced] @relation(name: "WORK_TRANSLATION", direction: "OUT")
   #######################################

--- a/src/schema/type/Review.graphql
+++ b/src/schema/type/Review.graphql
@@ -207,8 +207,8 @@ type Review implements MetadataInterface & SearchableInterface & ThingInterface 
   version: String
   "https://schema.org/video"
   video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
-  "https://schema.org/creativeWork"
-  workExample: [CreativeWorkInterfaced] @relation(name: "WORK_EXAMPLE", direction: "OUT")
+  "https://schema.org/workExample"
+  workExample: [CreativeWorkInterfaced] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
   "https://bib.schema.org/workTranslation"
   workTranslation: [CreativeWorkInterfaced] @relation(name: "WORK_TRANSLATION", direction: "OUT")
   #######################################

--- a/src/schema/type/SoftwareApplication.graphql
+++ b/src/schema/type/SoftwareApplication.graphql
@@ -207,8 +207,8 @@ type SoftwareApplication implements MetadataInterface & SearchableInterface & Th
   version: String
   "https://schema.org/video"
   video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
-  "https://schema.org/creativeWork"
-  workExample: [CreativeWorkInterfaced] @relation(name: "WORK_EXAMPLE", direction: "OUT")
+  "https://schema.org/workExample"
+  workExample: [CreativeWorkInterfaced] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
   "https://bib.schema.org/workTranslation"
   workTranslation: [CreativeWorkInterfaced] @relation(name: "WORK_TRANSLATION", direction: "OUT")
   ######################################

--- a/src/schema/type/VideoObject.graphql
+++ b/src/schema/type/VideoObject.graphql
@@ -207,8 +207,8 @@ type VideoObject implements MetadataInterface & SearchableInterface & ThingInter
   version: String
   "https://schema.org/video"
   video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
-  "https://schema.org/creativeWork"
-  workExample: [CreativeWorkInterfaced] @relation(name: "WORK_EXAMPLE", direction: "OUT")
+  "https://schema.org/workExample"
+  workExample: [CreativeWorkInterfaced] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
   "https://bib.schema.org/workTranslation"
   workTranslation: [CreativeWorkInterfaced] @relation(name: "WORK_TRANSLATION", direction: "OUT")
   #######################################


### PR DESCRIPTION
These relations are the inverse of each other as described on schema.org, https://schema.org/workExample and https://schema.org/exampleOfWork

We discussed in D2.3 that this would be a better relation between the two items instead of subjectOf, which I initially used.

Set the workExample relation in the schema to be EXAMPLE_OF_WORK with
direction IN so that it's automatically computed if exampleOfWork is set
as a relationship between two items.

Update ThingInterfaceRelationToCreativeWorkInterface to allow
exampleOfWork to be set between Things and CreativeWorks

![Screenshot 2019-10-24 at 12 00 40 PM](https://user-images.githubusercontent.com/19217/67475515-a6594780-f656-11e9-8cde-31fe46e5def3.png)
![Screenshot 2019-10-24 at 12 00 50 PM](https://user-images.githubusercontent.com/19217/67475525-a8bba180-f656-11e9-9810-5e38f172842e.png)
