### PR TITLE
make some fields optional

### DIFF
--- a/src/schema/enum.graphql
+++ b/src/schema/enum.graphql
@@ -167,11 +167,11 @@ enum ProvenanceAgentInterfaceType {
 
 enum AvailableLanguage {
   en
-  #  es
-  #  ca
-  #  nl
-  #  de
-  #  fr
+  es
+  ca
+  nl
+  de
+  fr
 }
 
 enum AccessMode {

--- a/src/schema/interface/MetadataInterface.graphql
+++ b/src/schema/interface/MetadataInterface.graphql
@@ -15,7 +15,7 @@ interface MetadataInterface {
   "http://purl.org/dc/elements/1.1/format"
   format: String
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher,https://schema.org/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/interface/ThingInterface.graphql
+++ b/src/schema/interface/ThingInterface.graphql
@@ -17,7 +17,7 @@ interface ThingInterface {
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
-  name: String!
+  name: String
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"

--- a/src/schema/type/Action.graphql
+++ b/src/schema/type/Action.graphql
@@ -18,7 +18,7 @@ type Action implements MetadataInterface & ThingInterface & ActionInterface & Pr
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/Action.graphql
+++ b/src/schema/type/Action.graphql
@@ -28,7 +28,7 @@ type Action implements MetadataInterface & ThingInterface & ActionInterface & Pr
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/Article.graphql
+++ b/src/schema/type/Article.graphql
@@ -49,7 +49,7 @@ type Article implements MetadataInterface & SearchableInterface & ThingInterface
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
-  name: String!
+  name: String
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"

--- a/src/schema/type/Article.graphql
+++ b/src/schema/type/Article.graphql
@@ -18,7 +18,7 @@ type Article implements MetadataInterface & SearchableInterface & ThingInterface
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/Article.graphql
+++ b/src/schema/type/Article.graphql
@@ -28,7 +28,7 @@ type Article implements MetadataInterface & SearchableInterface & ThingInterface
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/AudioObject.graphql
+++ b/src/schema/type/AudioObject.graphql
@@ -28,7 +28,7 @@ type AudioObject implements MetadataInterface & SearchableInterface & ThingInter
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/AudioObject.graphql
+++ b/src/schema/type/AudioObject.graphql
@@ -18,7 +18,7 @@ type AudioObject implements MetadataInterface & SearchableInterface & ThingInter
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/AudioObject.graphql
+++ b/src/schema/type/AudioObject.graphql
@@ -49,7 +49,7 @@ type AudioObject implements MetadataInterface & SearchableInterface & ThingInter
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
-  name: String!
+  name: String
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"

--- a/src/schema/type/CreativeWork.graphql
+++ b/src/schema/type/CreativeWork.graphql
@@ -28,7 +28,7 @@ type CreativeWork implements MetadataInterface & SearchableInterface & ThingInte
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/CreativeWork.graphql
+++ b/src/schema/type/CreativeWork.graphql
@@ -18,7 +18,7 @@ type CreativeWork implements MetadataInterface & SearchableInterface & ThingInte
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/CreativeWork.graphql
+++ b/src/schema/type/CreativeWork.graphql
@@ -49,7 +49,7 @@ type CreativeWork implements MetadataInterface & SearchableInterface & ThingInte
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
-  name: String!
+  name: String
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"

--- a/src/schema/type/DataDownload.graphql
+++ b/src/schema/type/DataDownload.graphql
@@ -28,7 +28,7 @@ type DataDownload implements MetadataInterface & SearchableInterface & ThingInte
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/DataDownload.graphql
+++ b/src/schema/type/DataDownload.graphql
@@ -18,7 +18,7 @@ type DataDownload implements MetadataInterface & SearchableInterface & ThingInte
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/Dataset.graphql
+++ b/src/schema/type/Dataset.graphql
@@ -18,7 +18,7 @@ type Dataset implements MetadataInterface & SearchableInterface & ThingInterface
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/Dataset.graphql
+++ b/src/schema/type/Dataset.graphql
@@ -28,7 +28,7 @@ type Dataset implements MetadataInterface & SearchableInterface & ThingInterface
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/DigitalDocument.graphql
+++ b/src/schema/type/DigitalDocument.graphql
@@ -49,7 +49,7 @@ type DigitalDocument implements MetadataInterface & SearchableInterface & ThingI
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
-  name: String!
+  name: String
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"

--- a/src/schema/type/DigitalDocument.graphql
+++ b/src/schema/type/DigitalDocument.graphql
@@ -28,7 +28,7 @@ type DigitalDocument implements MetadataInterface & SearchableInterface & ThingI
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/DigitalDocument.graphql
+++ b/src/schema/type/DigitalDocument.graphql
@@ -18,7 +18,7 @@ type DigitalDocument implements MetadataInterface & SearchableInterface & ThingI
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/EntryPoint.graphql
+++ b/src/schema/type/EntryPoint.graphql
@@ -18,7 +18,7 @@ type EntryPoint implements MetadataInterface & ThingInterface & ProvenanceEntity
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/EntryPoint.graphql
+++ b/src/schema/type/EntryPoint.graphql
@@ -28,7 +28,7 @@ type EntryPoint implements MetadataInterface & ThingInterface & ProvenanceEntity
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/Event.graphql
+++ b/src/schema/type/Event.graphql
@@ -18,7 +18,7 @@ type Event implements MetadataInterface & SearchableInterface & ThingInterface &
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/Event.graphql
+++ b/src/schema/type/Event.graphql
@@ -28,7 +28,7 @@ type Event implements MetadataInterface & SearchableInterface & ThingInterface &
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/ImageObject.graphql
+++ b/src/schema/type/ImageObject.graphql
@@ -18,7 +18,7 @@ type ImageObject implements MetadataInterface & SearchableInterface & ThingInter
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/ImageObject.graphql
+++ b/src/schema/type/ImageObject.graphql
@@ -28,7 +28,7 @@ type ImageObject implements MetadataInterface & SearchableInterface & ThingInter
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/Intangible.graphql
+++ b/src/schema/type/Intangible.graphql
@@ -18,7 +18,7 @@ type Intangible implements MetadataInterface & SearchableInterface & ThingInterf
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/Intangible.graphql
+++ b/src/schema/type/Intangible.graphql
@@ -28,7 +28,7 @@ type Intangible implements MetadataInterface & SearchableInterface & ThingInterf
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/MediaObject.graphql
+++ b/src/schema/type/MediaObject.graphql
@@ -18,7 +18,7 @@ type MediaObject implements MetadataInterface & SearchableInterface & ThingInter
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/MediaObject.graphql
+++ b/src/schema/type/MediaObject.graphql
@@ -28,7 +28,7 @@ type MediaObject implements MetadataInterface & SearchableInterface & ThingInter
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/MusicAlbum.graphql
+++ b/src/schema/type/MusicAlbum.graphql
@@ -28,7 +28,7 @@ type MusicAlbum implements MetadataInterface & SearchableInterface & ThingInterf
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/MusicAlbum.graphql
+++ b/src/schema/type/MusicAlbum.graphql
@@ -18,7 +18,7 @@ type MusicAlbum implements MetadataInterface & SearchableInterface & ThingInterf
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/MusicComposition.graphql
+++ b/src/schema/type/MusicComposition.graphql
@@ -28,7 +28,7 @@ type MusicComposition implements MetadataInterface & SearchableInterface & Thing
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String!
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/MusicComposition.graphql
+++ b/src/schema/type/MusicComposition.graphql
@@ -18,7 +18,7 @@ type MusicComposition implements MetadataInterface & SearchableInterface & Thing
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/MusicGroup.graphql
+++ b/src/schema/type/MusicGroup.graphql
@@ -18,7 +18,7 @@ type MusicGroup implements MetadataInterface & SearchableInterface & ThingInterf
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/MusicGroup.graphql
+++ b/src/schema/type/MusicGroup.graphql
@@ -28,7 +28,7 @@ type MusicGroup implements MetadataInterface & SearchableInterface & ThingInterf
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/MusicPlaylist.graphql
+++ b/src/schema/type/MusicPlaylist.graphql
@@ -28,7 +28,7 @@ type MusicPlaylist implements MetadataInterface & SearchableInterface & ThingInt
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/MusicPlaylist.graphql
+++ b/src/schema/type/MusicPlaylist.graphql
@@ -18,7 +18,7 @@ type MusicPlaylist implements MetadataInterface & SearchableInterface & ThingInt
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/MusicRecording.graphql
+++ b/src/schema/type/MusicRecording.graphql
@@ -28,7 +28,7 @@ type MusicRecording implements MetadataInterface & SearchableInterface & ThingIn
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/MusicRecording.graphql
+++ b/src/schema/type/MusicRecording.graphql
@@ -18,7 +18,7 @@ type MusicRecording implements MetadataInterface & SearchableInterface & ThingIn
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/Organization.graphql
+++ b/src/schema/type/Organization.graphql
@@ -28,7 +28,7 @@ type Organization implements MetadataInterface & SearchableInterface & ThingInte
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/Organization.graphql
+++ b/src/schema/type/Organization.graphql
@@ -18,7 +18,7 @@ type Organization implements MetadataInterface & SearchableInterface & ThingInte
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/Person.graphql
+++ b/src/schema/type/Person.graphql
@@ -18,7 +18,7 @@ type Person implements MetadataInterface & SearchableInterface & ThingInterface 
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/Person.graphql
+++ b/src/schema/type/Person.graphql
@@ -28,7 +28,7 @@ type Person implements MetadataInterface & SearchableInterface & ThingInterface 
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/Place.graphql
+++ b/src/schema/type/Place.graphql
@@ -18,7 +18,7 @@ type Place implements MetadataInterface & SearchableInterface & ThingInterface &
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/Place.graphql
+++ b/src/schema/type/Place.graphql
@@ -28,7 +28,7 @@ type Place implements MetadataInterface & SearchableInterface & ThingInterface &
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/Product.graphql
+++ b/src/schema/type/Product.graphql
@@ -28,7 +28,7 @@ type Product implements MetadataInterface & SearchableInterface & ThingInterface
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/Product.graphql
+++ b/src/schema/type/Product.graphql
@@ -18,7 +18,7 @@ type Product implements MetadataInterface & SearchableInterface & ThingInterface
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/Review.graphql
+++ b/src/schema/type/Review.graphql
@@ -18,7 +18,7 @@ type Review implements MetadataInterface & SearchableInterface & ThingInterface 
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/Review.graphql
+++ b/src/schema/type/Review.graphql
@@ -28,7 +28,7 @@ type Review implements MetadataInterface & SearchableInterface & ThingInterface 
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/SoftwareApplication.graphql
+++ b/src/schema/type/SoftwareApplication.graphql
@@ -18,7 +18,7 @@ type SoftwareApplication implements MetadataInterface & SearchableInterface & Th
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"

--- a/src/schema/type/SoftwareApplication.graphql
+++ b/src/schema/type/SoftwareApplication.graphql
@@ -28,7 +28,7 @@ type SoftwareApplication implements MetadataInterface & SearchableInterface & Th
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/VideoObject.graphql
+++ b/src/schema/type/VideoObject.graphql
@@ -49,7 +49,7 @@ type VideoObject implements MetadataInterface & SearchableInterface & ThingInter
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
-  name: String!
+  name: String
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"

--- a/src/schema/type/VideoObject.graphql
+++ b/src/schema/type/VideoObject.graphql
@@ -28,7 +28,7 @@ type VideoObject implements MetadataInterface & SearchableInterface & ThingInter
   "http://purl.org/dc/elements/1.1/source"
   source: String!
   "http://purl.org/dc/elements/1.1/subject"
-  subject: String!
+  subject: String
   "http://purl.org/dc/elements/1.1/title"
   title: String
   "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"

--- a/src/schema/type/VideoObject.graphql
+++ b/src/schema/type/VideoObject.graphql
@@ -18,7 +18,7 @@ type VideoObject implements MetadataInterface & SearchableInterface & ThingInter
   "http://purl.org/dc/elements/1.1/format"
   format: String!
   "http://purl.org/dc/elements/1.1/language"
-  language: AvailableLanguage!
+  language: AvailableLanguage
   "http://purl.org/dc/elements/1.1/publisher"
   publisher: String
   "http://purl.org/dc/elements/1.1/relation"


### PR DESCRIPTION
Fixes #81 
As discussed in Amsterdam, make subject optional
When @musicog and I were going through the schema design, we found some cases where it wasn't possible to add a language or name, so we are proposing to make those optional too. I only made name optional in the types that we're using at the moment, because I wasn't sure of the effect of making it optional in some of the other types. We can update this in the future if needed.