### PR TITLE
feat(schema): Add DefinedTermSet and DefinedTerm

### DIFF
--- a/src/schema/type/DefinedTerm.graphql
+++ b/src/schema/type/DefinedTerm.graphql
@@ -1,0 +1,70 @@
+"https://pending.schema.org/DefinedTerm"
+type DefinedTerm implements ThingInterface {
+    ### Metadata properties ###
+    "http://purl.org/dc/elements/1.1/identifier,https://schema.org/identifier"
+    identifier: ID
+    "http://purl.org/dc/elements/1.1/contributor,https://schema.org/contributor"
+    contributor: String
+    "http://purl.org/dc/elements/1.1/coverage"
+    coverage: String
+    "http://purl.org/dc/elements/1.1/creator"
+    creator: String!
+    "http://purl.org/dc/elements/1.1/date"
+    date: _Neo4jDate
+    "http://purl.org/dc/elements/1.1/description,https://schema.org/description"
+    description: String
+    "https://schema.org/disambiguatingDescription"
+    disambiguatingDescription: String
+    "http://purl.org/dc/elements/1.1/format"
+    format: String
+    "http://purl.org/dc/elements/1.1/language"
+    language: AvailableLanguage
+    "http://purl.org/dc/elements/1.1/publisher"
+    publisher: String
+    "http://purl.org/dc/elements/1.1/relation"
+    relation: String
+    "http://purl.org/dc/elements/1.1/rights"
+    rights: String
+    "http://purl.org/dc/elements/1.1/source"
+    source: String
+    "http://purl.org/dc/elements/1.1/subject"
+    subject: String
+    "http://purl.org/dc/elements/1.1/title"
+    title: String
+    "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"
+    type: String
+    "http://purl.org/dc/elements/1.1/date"
+    created: String
+    "http://purl.org/dc/elements/1.1/date"
+    updated: String
+    #################################
+    ### ThingInterface properties ###
+    "https://schema.org/additionalType"
+    additionalType: [String]
+    "https://schema.org/additionalProperty"
+    additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: "OUT")
+    "https://schema.org/alternateName"
+    alternateName: String
+    "https://schema.org/image"
+    image: URL
+    "https://schema.org/mainEntityOfPage"
+    mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
+    "https://schema.org/name"
+    name: String
+    "https://schema.org/potentialAction"
+    potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
+    "https://schema.org/sameAs"
+    sameAs: URL
+    "https://schema.org/subjectOf"
+    subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
+    "https://schema.org/url"
+    url: URL
+    ##############################
+    ### DefinedTerm properties ###
+    "https://pending.schema.org/termCode"
+    termCode: String!
+    # TODO: inDefinedTermSet can also be a URL, is this needed in the CE?
+    # TODO: This should only be a relation to one DefinedTermSet
+    "https://pending.schema.org/inDefinedTermSet"
+    inDefinedTermSet: [DefinedTermSet] @relation(name: "HAS_DEFINED_TERM", direction: "IN")
+}

--- a/src/schema/type/DefinedTermSet.graphql
+++ b/src/schema/type/DefinedTermSet.graphql
@@ -1,0 +1,197 @@
+"https://pending.schema.org/DefinedTermSet"
+type DefinedTermSet implements CreativeWorkInterface & ThingInterface {
+    ### Metadata properties ###
+    "http://purl.org/dc/elements/1.1/identifier,https://schema.org/identifier"
+    identifier: ID
+    "http://purl.org/dc/elements/1.1/contributor,https://schema.org/contributor"
+    contributor: String
+    "http://purl.org/dc/elements/1.1/coverage"
+    coverage: String
+    "http://purl.org/dc/elements/1.1/creator"
+    creator: String!
+    "http://purl.org/dc/elements/1.1/date"
+    date: _Neo4jDate
+    "http://purl.org/dc/elements/1.1/description,https://schema.org/description"
+    description: String
+    "https://schema.org/disambiguatingDescription"
+    disambiguatingDescription: String
+    "http://purl.org/dc/elements/1.1/format"
+    format: String
+    "http://purl.org/dc/elements/1.1/language"
+    language: AvailableLanguage
+    "http://purl.org/dc/elements/1.1/publisher"
+    publisher: String
+    "http://purl.org/dc/elements/1.1/relation"
+    relation: String
+    "http://purl.org/dc/elements/1.1/rights"
+    rights: String
+    "http://purl.org/dc/elements/1.1/source"
+    source: String
+    "http://purl.org/dc/elements/1.1/subject"
+    subject: String
+    "http://purl.org/dc/elements/1.1/title"
+    title: String
+    "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"
+    type: String
+    "http://purl.org/dc/elements/1.1/date"
+    created: String
+    "http://purl.org/dc/elements/1.1/date"
+    updated: String
+    #################################
+    ### ThingInterface properties ###
+    "https://schema.org/additionalType"
+    additionalType: [String]
+    "https://schema.org/additionalProperty"
+    additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: "OUT")
+    "https://schema.org/alternateName"
+    alternateName: String
+    "https://schema.org/image"
+    image: URL
+    "https://schema.org/mainEntityOfPage"
+    mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
+    "https://schema.org/name"
+    name: String!
+    "https://schema.org/potentialAction"
+    potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
+    "https://schema.org/sameAs"
+    sameAs: URL
+    "https://schema.org/subjectOf"
+    subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
+    "https://schema.org/url"
+    url: URL
+    ###############################
+    ### CreativeWork properties ###
+    "https://schema.org/about"
+    about: [ThingInterface] @relation(name: "ABOUT", direction: "OUT")
+    #"https://schema.org/accessMode"
+    #accessMode: AccessMode
+    #"https://schema.org/accessModeSufficient"
+    #accessModeSufficient: AccessMode
+    #accessibilityAPI: String
+    #accessibilityControl: String
+    #accessibilityFeature: String
+    #accessibilityHazard: String
+    #accessibilitySummary: String
+    "https://schema.org/accountablePerson"
+    accountablePerson: [Person] @relation(name: "ACCOUNTABLE_PERSON", direction: "OUT")
+    #aggregateRating: AggregateRating
+    "https://schema.org/alternativeHeadline"
+    alternativeHeadline: String
+    "https://schema.org/associatedMedia"
+    associatedMedia: [MediaObjectInterface] @relation(name: "ASSOCIATED_MEDIA", direction: "OUT")
+    #audience: Audience
+    "https://schema.org/audio"
+    audio: [AudioObject] @relation(name: "AUDIO", direction: "OUT")
+    "https://schema.org/author"
+    author: [LegalPersonInterface] @relation(name: "AUTHOR", direction: "OUT")
+    "https://schema.org/award"
+    award: String
+    "https://schema.org/character"
+    character: [Person] @relation(name: "CHARACTER", direction: "IN")
+    "https://schema.org/citation"
+    citation: [CreativeWorkInterface] @relation(name: "CITATION", direction: "IN")
+    #"https://schema.org/comment"
+    #comment: Comment
+    #"https://schema.org/commentCount"
+    #commentCount: Int
+    #contentLocation: Place
+    #contentRating: Rating | String
+    #contentReferenceTime: _Neo4jDateTime
+    #contributor: String! | LegalPersonInterface @relation(name: "AUTHOR", direction: "OUT")
+    "https://schema.org/copyrightHolder"
+    copyrightHolder: [LegalPersonInterface] @relation(name: "COPYRIGHT_HOLDER", direction: "OUT")
+    "https://schema.org/copyrightYear"
+    copyrightYear: Int
+    #correction: String
+    #creator: String! | LegalPersonInterface @relation(name: "AUTHOR", direction: "OUT")
+    #dateCreated: _Neo4jDate
+    "https://schema.org/dateModified"
+    dateModified: _Neo4jDateTime
+    "https://schema.org/datePublished"
+    datePublished: _Neo4jDate
+    #discussionUrl: URL
+    editor: [Person] @relation(name: "EDITOR", direction: "IN")
+    #educationalAlignment
+    #educationalUse
+    "https://schema.org/encoding"
+    encoding: [MediaObjectInterface] @relation(name: "ENCODING", direction: "IN")
+    "https://schema.org/encodingFormat"
+    encodingFormat: String
+    "https://schema.org/exampleOfWork"
+    exampleOfWork: [CreativeWorkInterface] @relation(name: "EXAMPLE_OF_WORK", direction: "OUT")
+    "https://schema.org/expires"
+    expires: _Neo4jDate
+    "https://schema.org/funder"
+    funder: [LegalPersonInterface] @relation(name: "FUNDER", direction: "IN")
+    "https://schema.org/genre"
+    genre: String
+    "https://schema.org/hasPart"
+    hasPart: [CreativeWorkInterface] @relation(name: "HAS_PART", direction: "OUT")
+    "https://schema.org/headline"
+    headline: String
+    "https://schema.org/inLanguage"
+    inLanguage: String
+    #interactionStatistic
+    #interactivityType
+    "https://schema.org/isBasedOn"
+    isBasedOn: [CreativeWorkInterface] @relation(name: "IS_BASED_ON", direction: "OUT")
+    #isFamilyFriendly: Boolean
+    "https://schema.org/isPartOf"
+    isPartOf: CreativeWorkInterface @relation(name: "IS_PART_OF", direction: "OUT")
+    "https://schema.org/keywords"
+    keywords: String
+    #learningResourceType: String
+    "https://schema.org/license"
+    license: URL
+    #locationCreated
+    "https://schema.org/mainEntity"
+    mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "IN")
+    #material
+    "https://schema.org/mentions"
+    mentions: [ThingInterface] @relation(name: "MENTIONS", direction: "OUT")
+    #offers:
+    "https://schema.org/position"
+    position: Int
+    "https://schema.org/producer"
+    producer: [LegalPersonInterface] @relation(name: "PRODUCER", direction: "IN")
+    #provider:
+    #publication:
+    "https://schema.org/publisher"
+    schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
+    #publisherImprint: OrganizationInterface
+    "https://schema.org/publishingPrinciples"
+    publishingPrinciples: URL
+    "https://schema.org/recordedAt"
+    recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
+    #releasedEvent:
+    #review:
+    #schemaVersion:
+    #sdDatePublished:
+    #sdLicense:
+    #sdPublisher:
+    "https://schema.org/sourceOrganization"
+    sourceOrganization: Organization @relation(name: "SOURCE_ORGANIZATION", direction: "IN")
+    #spatialCoverage:
+    #sponsor:
+    #temporalCoverage:
+    "https://schema.org/text"
+    text: String
+    "https://schema.org/thumbnailUrl"
+    thumbnailUrl: URL
+    #timeRequired:
+    "https://schema.org/translator"
+    translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
+    #typicalAgeRange:
+    "https://schema.org/version"
+    version: String
+    "https://schema.org/video"
+    video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
+    "https://schema.org/workExample"
+    workExample: [CreativeWorkInterface] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
+    "https://bib.schema.org/workTranslation"
+    workTranslation: [CreativeWorkInterface] @relation(name: "WORK_TRANSLATION", direction: "OUT")
+    #################################
+    ### DefinedTermSet properties ###
+    "https://pending.schema.org/hasDefinedTerm"
+    hasDefinedTerm: [DefinedTerm] @relation(name: "HAS_DEFINED_TERM", direction: "OUT")
+}


### PR DESCRIPTION
Fixes #88

As part of the development of the Annotation schema, we realised that we needed a way of creating a closed vocabulary of terms that could be used in an annotation, for example if someone wants to annotate a performance as one of (excellent, good, needs work).
@musicog found the [DefinedTerm specification](https://schema.org/DefinedTerm), which is currently on pending.schema.org, but fulfils our requirements.

Add to the schema the ability to create a DefinedTermSet, and add DefinedTerms to it.