### PR TITLE
feat(schema): Add Rating from schema.org

### DIFF
--- a/src/schema/type/DefinedTerm.graphql
+++ b/src/schema/type/DefinedTerm.graphql
@@ -33,10 +33,10 @@ type DefinedTerm implements ThingInterface {
     title: String
     "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"
     type: String
-    "http://purl.org/dc/elements/1.1/date"
+    "http://purl.org/dc/terms/created"
     created: String
-    "http://purl.org/dc/elements/1.1/date"
-    updated: String
+    "http://purl.org/dc/terms/modified"
+    modified: String
     #################################
     ### ThingInterface properties ###
     "https://schema.org/additionalType"

--- a/src/schema/type/DefinedTermSet.graphql
+++ b/src/schema/type/DefinedTermSet.graphql
@@ -33,10 +33,10 @@ type DefinedTermSet implements CreativeWorkInterface & ThingInterface {
     title: String
     "http://purl.org/dc/elements/1.1/type,https://www.w3.org/2000/01/rdf-schema#type"
     type: String
-    "http://purl.org/dc/elements/1.1/date"
+    "http://purl.org/dc/terms/created"
     created: String
-    "http://purl.org/dc/elements/1.1/date"
-    updated: String
+    "http://purl.org/dc/terms/modified"
+    modified: String
     #################################
     ### ThingInterface properties ###
     "https://schema.org/additionalType"

--- a/src/schema/type/Rating.graphql
+++ b/src/schema/type/Rating.graphql
@@ -17,6 +17,8 @@ type Rating implements ThingInterface {
     title: String
     "http://purl.org/dc/terms/created"
     created: String
+    "http://purl.org/dc/terms/modified"
+    modified: String
     #################################
     ### ThingInterface properties ###
     "https://schema.org/additionalType"

--- a/src/schema/type/Rating.graphql
+++ b/src/schema/type/Rating.graphql
@@ -1,0 +1,56 @@
+"https://schema.org/Rating"
+type Rating implements ThingInterface {
+    ### Metadata properties ###
+    "http://purl.org/dc/elements/1.1/identifier,https://schema.org/identifier"
+    identifier: ID
+    "http://purl.org/dc/elements/1.1/contributor,https://schema.org/contributor"
+    contributor: String
+    "http://purl.org/dc/elements/1.1/creator"
+    creator: String!
+    "http://purl.org/dc/elements/1.1/description,https://schema.org/description"
+    description: String
+    "https://schema.org/disambiguatingDescription"
+    disambiguatingDescription: String
+    "http://purl.org/dc/elements/1.1/language"
+    language: AvailableLanguage
+    "http://purl.org/dc/elements/1.1/title"
+    title: String
+    "http://purl.org/dc/terms/created"
+    created: String
+    #################################
+    ### ThingInterface properties ###
+    "https://schema.org/additionalType"
+    additionalType: [String]
+    "https://schema.org/additionalProperty"
+    additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: "OUT")
+    "https://schema.org/alternateName"
+    alternateName: String
+    "https://schema.org/image"
+    image: URL
+    "https://schema.org/mainEntityOfPage"
+    mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
+    "https://schema.org/name"
+    name: String
+    "https://schema.org/potentialAction"
+    potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
+    "https://schema.org/sameAs"
+    sameAs: URL
+    "https://schema.org/subjectOf"
+    subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
+    "https://schema.org/url"
+    url: URL
+    #########################
+    ### Rating properties ###
+    "https://schema.org/author"
+    author: String
+    "https://schema.org/bestRating"
+    bestRating: Int
+    "https://pending.schema.org/ratingExplanation"
+    ratingExplanation: String
+    "https://schema.org/ratingValue"
+    ratingValue: Int
+    "https://schema.org/reviewAspect"
+    reviewAspect: String
+    "https://schema.org/worstRating"
+    worstRating: Int
+}

--- a/src/schema/type/Rating.graphql
+++ b/src/schema/type/Rating.graphql
@@ -46,11 +46,11 @@ type Rating implements ThingInterface {
     "https://schema.org/author"
     author: String
     "https://schema.org/bestRating"
-    bestRating: Int
+    bestRating: Int!
     "https://pending.schema.org/ratingExplanation"
     ratingExplanation: String
     "https://schema.org/ratingValue"
-    ratingValue: Int
+    ratingValue: Int!
     "https://schema.org/reviewAspect"
     reviewAspect: String
     "https://schema.org/worstRating"


### PR DESCRIPTION
A new type which is needed for annotations.
A Rating (https://schema.org/Rating) is an evaluation on a numeric scale, such as 1 to 5 stars.
