### PR TITLE
feat(project): update build and start scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .idea/*
+/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@ WORKDIR /app
 COPY package.json .
 COPY package-lock.json .
 RUN npm install
+RUN npm build
 COPY . .
 
 EXPOSE 80
 
-CMD ["npm", "start"]
+CMD ["npm", "start:prod"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1314,6 +1314,17 @@
         "rimraf": "^2.5.4",
         "slash": "^2.0.0",
         "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "@jest/environment": {
@@ -1470,6 +1481,17 @@
         "graceful-fs": "^4.1.3",
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -5021,6 +5043,17 @@
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -7089,6 +7122,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         },
         "source-map": {
           "version": "0.6.1",
@@ -9814,9 +9856,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "build": "rimraf ./dist && babel ./src --out-dir ./dist --copy-files",
     "build:debug": "rimraf ./dist && babel ./src --out-dir ./dist --copy-files --source-maps",
     "lint": "eslint src tests",
-    "start": "babel-node --watch src src/index.js",
+    "start": "nodemon --exec babel-node --watch src src/index.js",
     "start:prod": "nodemon --exec node dist/index.js",
     "test:functional": "CI=true jest tests/helpers.js tests/functional",
     "version": "conventional-changelog -i CHANGELOG.md -s && git add -A CHANGELOG.md"

--- a/package.json
+++ b/package.json
@@ -46,11 +46,15 @@
     "jest": "^24.9.0",
     "lint-staged": "9.5.*",
     "node-fetch": "2.3.*",
-    "nodemon": "^1.19.1"
+    "nodemon": "^1.19.1",
+    "rimraf": "^3.0.2"
   },
   "scripts": {
+    "build": "rimraf ./dist && babel ./src --out-dir ./dist --copy-files",
+    "build:debug": "rimraf ./dist && babel ./src --out-dir ./dist --copy-files --source-maps",
     "lint": "eslint src tests",
-    "start": "nodemon --exec babel-node --watch src src/index.js",
+    "start": "babel-node --watch src src/index.js",
+    "start:prod": "nodemon --exec node dist/index.js",
     "test:functional": "CI=true jest tests/helpers.js tests/functional",
     "version": "conventional-changelog -i CHANGELOG.md -s && git add -A CHANGELOG.md"
   },


### PR DESCRIPTION
I've updated the build and start script since this was still using the `babel-node` script which is [not recommended](https://babeljs.io/docs/en/next/babel-node.html#not-meant-for-production-use) by the creators of Babel.

You can still use `npm run start` to start a debug server with live reload enabled, but for the Docker build and for `node --inspect` you can use the `npm run build:debug` and `npm run start:prod` respectively.