### PR TITLE
fix(graphql): fix error when deleting non-existing node

### DIFF
--- a/src/transformers/subscriptionFieldTransformer.js
+++ b/src/transformers/subscriptionFieldTransformer.js
@@ -1,5 +1,6 @@
 import { TransformRootFields } from 'graphql-tools'
 import { pubsub } from '../resolvers'
+import { parseFieldName } from '../utils/schema'
 
 // add custom subscription triggers for specific types (key)
 const customTypeTriggers = {
@@ -10,12 +11,14 @@ const customTypeTriggers = {
 
 export const subscriptionFieldTransformer = new TransformRootFields((operation, fieldName, field) => {
   // subscriptions are only triggered for mutations
-  if (operation !== 'Mutation' || fieldName === 'RequestControlAction') {
+  if (operation !== 'Mutation') {
     return undefined
   }
 
-  // ignore custom mutations with custom resolvers
-  if (fieldName === 'UpdateControlAction' || fieldName === 'RequestControlAction') {
+  const { action } = parseFieldName(fieldName)
+
+  // ignore non Create mutations and custom mutations with custom resolvers
+  if (action !== 'Create' || fieldName === 'UpdateControlAction' || fieldName === 'RequestControlAction') {
     return undefined
   }
 

--- a/src/utils/schema.js
+++ b/src/utils/schema.js
@@ -1,11 +1,25 @@
 /**
+ * Parse the given field name into an action and type
+ * @param {string} fieldName
+ * @returns {{ action: string, type: string }}
+ */
+export const parseFieldName = (fieldName) => {
+  const [, action, type] = fieldName.match(/^([A-Z][a-z]+)([A-Z]\w+)/)
+
+  return {
+    action,
+    type
+  }
+}
+
+/**
  * Generate a scope from the given mutation and fieldName
  * @param {string} mutation
  * @param {string} fieldName
  * @returns {string}
  */
 export const generateScope = (mutation, fieldName) => {
-  const [, action, type] = fieldName.match(/^([A-Z][a-z]+)([A-Z]\w+)/)
+  const { action, type } = parseFieldName(fieldName)
 
   return `${mutation}:${type}:${action}`
 }

--- a/src/utils/schema.test.js
+++ b/src/utils/schema.test.js
@@ -1,4 +1,14 @@
-import { generateScope } from './schema'
+import { generateScope, parseFieldName } from './schema'
+
+describe('parseFieldName', function () {
+  it('should parse the field name into action and type', () => {
+    expect(parseFieldName('CreatePerson')).toMatchObject({ action: 'Create', type: 'Person' })
+    expect(parseFieldName('DeletePerson')).toMatchObject({ action: 'Delete', type: 'Person' })
+    expect(parseFieldName('MergePerson')).toMatchObject({ action: 'Merge', type: 'Person' })
+    expect(parseFieldName('AddMusicCompositionComposer')).toMatchObject({ action: 'Add', type: 'MusicCompositionComposer' })
+    expect(parseFieldName('RemoveMusicCompositionComposer')).toMatchObject({ action: 'Remove', type: 'MusicCompositionComposer' })
+  })
+})
 
 describe('generateScope', function () {
   it('should generate the scope correctly', () => {


### PR DESCRIPTION
This PR fixes #107 and will prevent `ThingCreateMutation` being triggered for `Delete`, `Merge`, `Update`, `Add` and `Remove` mutations.