### PR TITLE
Feat/control action agent participant proposal

### DIFF
--- a/src/helpers/SchemaHelper.js
+++ b/src/helpers/SchemaHelper.js
@@ -74,6 +74,17 @@ class SchemaHelper {
   }
 
   /**
+   * Get all schema type names
+   * @returns {string[]}
+   */
+  getTypeNames () {
+    return Object
+      .values(this.schemaTypeMap)
+      .filter(type => type.astNode && type.astNode.kind === 'ObjectTypeDefinition' && !!type.astNode.interfaces.length)
+      .map(type => type.name)
+  }
+
+  /**
    * @param typeName
    * @returns {*}
    */

--- a/src/queries/GetTypeQuery.js
+++ b/src/queries/GetTypeQuery.js
@@ -1,9 +1,13 @@
+import QueryHelper from '../helpers/QueryHelper'
+
 class GetTypeQuery {
   /**
    * @param identifier
+   * @param [typeNames]
    */
-  constructor (identifier) {
+  constructor (identifier, typeNames) {
     this.identifier = identifier
+    this.typeNames = typeNames
   }
 
   /**
@@ -21,7 +25,7 @@ class GetTypeQuery {
     return [
       `MATCH (\`n\`)`,
       `WHERE \`n\`.\`identifier\` = "${this.identifier}"`,
-      `RETURN \`n\` {\`_schemaType\`:HEAD(labels(\`n\`))} AS \`_payload\``
+      `RETURN \`n\` { ${QueryHelper.schemaTypeClause('n', this.typeNames)} } AS \`_payload\``
     ].join(' ')
   }
 }

--- a/src/routes/helpers/document.js
+++ b/src/routes/helpers/document.js
@@ -2,11 +2,13 @@ import { info } from '../../utils/logger'
 import { driver } from '../../driver'
 import GetTypeQuery from '../../queries/GetTypeQuery'
 import GetFullNodeQuery from '../../queries/GetFullNodeQuery'
+import SchemaHelper from '../../helpers/SchemaHelper'
 
 export const getDocument = (identifier, host) => {
   const session = driver.session()
+  const schemaHelper = new SchemaHelper()
 
-  const getTypeQuery = new GetTypeQuery(identifier)
+  const getTypeQuery = new GetTypeQuery(identifier, schemaHelper.getTypeNames())
   const query = getTypeQuery.query
 
   info(`_findNodeType query: ${query}`)

--- a/src/routes/helpers/transformers.js
+++ b/src/routes/helpers/transformers.js
@@ -1,7 +1,6 @@
 import SchemaHelper from '../../helpers/SchemaHelper'
 import { warning } from '../../utils/logger'
 import { isDateTime } from 'neo4j-driver/lib/temporal-types'
-import { schema } from '../../schema'
 
 // Used scopes dict
 const scopedContexts = {

--- a/src/routes/helpers/transformers.js
+++ b/src/routes/helpers/transformers.js
@@ -5,7 +5,7 @@ import { isDateTime } from 'neo4j-driver/lib/temporal-types'
 // Used scopes dict
 const scopedContexts = {
   dc: 'http://purl.org/dc/elements/1.1/',
-  prov: 'https://www.w3.org/TR/prov-o/#',
+  prov: 'http://www.w3.org/ns/prov#',
   skos: 'http://www.w3.org/2004/02/skos/core#',
   rdf: 'https://www.w3.org/2000/01/rdf-schema'
 }

--- a/src/schema/interface/ActionInterface.graphql
+++ b/src/schema/interface/ActionInterface.graphql
@@ -2,10 +2,10 @@
 interface ActionInterface {
   "http://purl.org/dc/elements/1.1/identifier,https://schema.org/identifier"
   identifier: ID
-  #"https://schema.org/actionStatus"
-  #actionStatus: String
+  "https://schema.org/actionStatus"
+  actionStatus: ActionStatusType
   "https://schema.org/agent"
-  agent: [LegalPersonInterface] @relation(name: "AGENT", direction: "OUT")
+  agent: String
   "https://schema.org/endTime"
   endTime: _Neo4jDateTime
   "https://schema.org/error"
@@ -14,10 +14,10 @@ interface ActionInterface {
   instrument: [ThingInterface] @relation(name: "INSTRUMENT", direction: "OUT")
   "https://schema.org/location"
   location: [Place] @relation(name: "LOCATION", direction: "OUT")
-  "https://schema.org/object"
-  #  object: [ThingInterface] @relation(name: "OBJECT", direction: "OUT")
-  #  "https://schema.org/participant"
-  participant: [LegalPersonInterface] @relation(name: "PARTICIPANT", direction: "OUT")
+  # "https://schema.org/object"
+  # object: [ThingInterface] @relation(name: "OBJECT", direction: "OUT")
+  "https://schema.org/participant"
+  participant: [String]
   "https://schema.org/result"
   result: ThingInterface @relation(name: "RESULT", direction: "OUT")
   "https://schema.org/startTime"

--- a/src/schema/interface/ProvenanceActivityInterface.graphql
+++ b/src/schema/interface/ProvenanceActivityInterface.graphql
@@ -2,10 +2,10 @@
 interface ProvenanceActivityInterface {
   "http://purl.org/dc/elements/1.1/identifier,https://schema.org/identifier"
   identifier: ID
-  "https://www.w3.org/TR/prov-o/#startedAtTime"
+  "http://www.w3.org/ns/prov#startedAtTime"
   startedAtTime: _Neo4jDateTime
-  "https://www.w3.org/TR/prov-o/#wasInformedBy"
+  "http://www.w3.org/ns/prov#wasInformedBy"
   wasInformedBy: [ActionInterface] @relation(name: "WAS_INFORMED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#endedAtTime"
+  "http://www.w3.org/ns/prov#endedAtTime"
   endedAtTime: _Neo4jDateTime
 }

--- a/src/schema/interface/ProvenanceAgentInterface.graphql
+++ b/src/schema/interface/ProvenanceAgentInterface.graphql
@@ -2,8 +2,8 @@
 interface ProvenanceAgentInterface {
   "http://purl.org/dc/elements/1.1/identifier,https://schema.org/identifier"
   identifier: ID
-  "https://www.w3.org/TR/prov-o/#wasAssociatedWith"
+  "http://www.w3.org/ns/prov#wasAssociatedWith"
   wasAssociatedWith: [LegalPersonInterface] @relation(name: "WAS_ASSOCIATED_WITH", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#actedOnBehalfOf"
+  "http://www.w3.org/ns/prov#actedOnBehalfOf"
   actedOnBehalfOf: [LegalPersonInterface] @relation(name: "ACTED_ON_BEHALF_OF", direction: "OUT")
 }

--- a/src/schema/interface/ProvenanceEntityInterface.graphql
+++ b/src/schema/interface/ProvenanceEntityInterface.graphql
@@ -2,12 +2,12 @@
 interface ProvenanceEntityInterface {
   "http://purl.org/dc/elements/1.1/identifier,https://schema.org/identifier"
   identifier: ID
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
 }

--- a/src/schema/interface/ThingInterface.graphql
+++ b/src/schema/interface/ThingInterface.graphql
@@ -1,4 +1,4 @@
-"https://schema.org/Thing,https://www.w3.org/TR/prov-o/#Entity"
+"https://schema.org/Thing,http://www.w3.org/ns/prov#Entity"
 interface ThingInterface {
   "http://purl.org/dc/elements/1.1/identifier,https://schema.org/identifier"
   identifier: ID

--- a/src/schema/mutation.graphql
+++ b/src/schema/mutation.graphql
@@ -1,4 +1,3 @@
 type Mutation {
   RequestControlAction(identifier: ID, controlAction: RequestControlActionInput): ControlAction
-  UpdateControlAction(identifier: ID, actionStatus: ActionStatusType, error: String, url: String): ControlAction
 }

--- a/src/schema/type/Action.graphql
+++ b/src/schema/type/Action.graphql
@@ -90,10 +90,10 @@ type Action implements MetadataInterface & ThingInterface & ActionInterface & Pr
   endedAtTime: _Neo4jDateTime
   ##################################
   ### ActionInterface properties ###
-  #"https://schema.org/actionStatus"
-  #actionStatus: String
+  "https://schema.org/actionStatus"
+  actionStatus: ActionStatusType
   "https://schema.org/agent"
-  agent: [LegalPersonInterface] @relation(name: "AGENT", direction: "OUT")
+  agent: String
   "https://schema.org/endTime"
   endTime: _Neo4jDateTime
   "https://schema.org/error"
@@ -105,7 +105,7 @@ type Action implements MetadataInterface & ThingInterface & ActionInterface & Pr
   "https://schema.org/object"
   object: [ThingInterface] @relation(name: "OBJECT", direction: "OUT")
   "https://schema.org/participant"
-  participant: [LegalPersonInterface] @relation(name: "PARTICIPANT", direction: "OUT")
+  participant: [String]
   "https://schema.org/result"
   result: ThingInterface @relation(name: "RESULT", direction: "OUT")
   "https://schema.org/startTime"

--- a/src/schema/type/Action.graphql
+++ b/src/schema/type/Action.graphql
@@ -1,4 +1,4 @@
-"https://schema.org/Action,https://www.w3.org/TR/prov-o/#Activity"
+"https://schema.org/Action,http://www.w3.org/ns/prov#Activity"
 type Action implements MetadataInterface & ThingInterface & ActionInterface & ProvenanceEntityInterface & ProvenanceActivityInterface {
   ### Metadata properties ###
   "http://purl.org/dc/elements/1.1/identifier,https://schema.org/identifier"
@@ -72,21 +72,21 @@ type Action implements MetadataInterface & ThingInterface & ActionInterface & Pr
   relatedMatch: [ThingInterface]  @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ##############################################
   ### ProvenanceActivityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#startedAtTime"
+  "http://www.w3.org/ns/prov#startedAtTime"
   startedAtTime: _Neo4jDateTime
-  "https://www.w3.org/TR/prov-o/#wasInformedBy"
+  "http://www.w3.org/ns/prov#wasInformedBy"
   wasInformedBy: [ActionInterface] @relation(name: "WAS_INFORMED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#endedAtTime"
+  "http://www.w3.org/ns/prov#endedAtTime"
   endedAtTime: _Neo4jDateTime
   ##################################
   ### ActionInterface properties ###

--- a/src/schema/type/AddAction.graphql
+++ b/src/schema/type/AddAction.graphql
@@ -1,4 +1,4 @@
-"https://schema.org/AddAction,https://www.w3.org/TR/prov-o/#Activity"
+"https://schema.org/AddAction,http://www.w3.org/ns/prov#Activity"
 type AddAction implements ThingInterface & ActionInterface & ProvenanceEntityInterface & ProvenanceActivityInterface {
   ########################
   ### ThingInterface properties ###
@@ -30,21 +30,21 @@ type AddAction implements ThingInterface & ActionInterface & ProvenanceEntityInt
   url: URL
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ##############################################
   ### ProvenanceActivityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#startedAtTime"
+  "http://www.w3.org/ns/prov#startedAtTime"
   startedAtTime: _Neo4jDateTime
-  "https://www.w3.org/TR/prov-o/#wasInformedBy"
+  "http://www.w3.org/ns/prov#wasInformedBy"
   wasInformedBy: [ActionInterface] @relation(name: "WAS_INFORMED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#endedAtTime"
+  "http://www.w3.org/ns/prov#endedAtTime"
   endedAtTime: _Neo4jDateTime
   ##################################
   ### ActionInterface properties ###

--- a/src/schema/type/AddAction.graphql
+++ b/src/schema/type/AddAction.graphql
@@ -48,10 +48,10 @@ type AddAction implements ThingInterface & ActionInterface & ProvenanceEntityInt
   endedAtTime: _Neo4jDateTime
   ##################################
   ### ActionInterface properties ###
-  #"https://schema.org/actionStatus"
-  #actionStatus: String
+  "https://schema.org/actionStatus"
+  actionStatus: ActionStatusType
   "https://schema.org/agent"
-  agent: [LegalPersonInterface] @relation(name: "AGENT", direction: "OUT")
+  agent: String
   "https://schema.org/endTime"
   endTime: _Neo4jDateTime
   "https://schema.org/error"
@@ -63,7 +63,7 @@ type AddAction implements ThingInterface & ActionInterface & ProvenanceEntityInt
   "https://schema.org/object"
   object: [ThingInterface] @relation(name: "OBJECT", direction: "OUT")
   "https://schema.org/participant"
-  participant: [LegalPersonInterface] @relation(name: "PARTICIPANT", direction: "OUT")
+  participant: [String]
   "https://schema.org/result"
   result: ThingInterface @relation(name: "RESULT", direction: "OUT")
   "https://schema.org/startTime"

--- a/src/schema/type/Article.graphql
+++ b/src/schema/type/Article.graphql
@@ -72,13 +72,13 @@ type Article implements MetadataInterface & SearchableInterface & ThingInterface
   relatedMatch: [ThingInterface]  @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###############################
   ### CreativeWork properties ###

--- a/src/schema/type/AudioObject.graphql
+++ b/src/schema/type/AudioObject.graphql
@@ -72,13 +72,13 @@ type AudioObject implements MetadataInterface & SearchableInterface & ThingInter
   relatedMatch: [ThingInterface] @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###############################
   ### CreativeWork properties ###

--- a/src/schema/type/ControlAction.graphql
+++ b/src/schema/type/ControlAction.graphql
@@ -55,7 +55,7 @@ type ControlAction implements ThingInterface & ActionInterface & ProvenanceEntit
   "https://schema.org/actionStatus"
   actionStatus: ActionStatusType
   "https://schema.org/agent"
-  agent: [LegalPersonInterface] @relation(name: "AGENT", direction: "OUT")
+  agent: String
   "https://schema.org/endTime"
   endTime: _Neo4jDateTime
   "https://schema.org/error"
@@ -67,7 +67,7 @@ type ControlAction implements ThingInterface & ActionInterface & ProvenanceEntit
   "https://schema.org/object"
   object: [ThingInterface] @relation(name: "OBJECT", direction: "OUT")
   "https://schema.org/participant"
-  participant: [LegalPersonInterface] @relation(name: "PARTICIPANT", direction: "OUT")
+  participant: [String]
   "https://schema.org/result"
   result: ThingInterface @relation(name: "RESULT", direction: "OUT")
   "https://schema.org/startTime"

--- a/src/schema/type/ControlAction.graphql
+++ b/src/schema/type/ControlAction.graphql
@@ -1,4 +1,4 @@
-"https://schema.org/ControlAction,https://www.w3.org/TR/prov-o/#Activity"
+"https://schema.org/ControlAction,http://www.w3.org/ns/prov#Activity"
 type ControlAction implements ThingInterface & ActionInterface & ProvenanceEntityInterface & ProvenanceActivityInterface {
   ########################
   ### ThingInterface properties ###
@@ -34,21 +34,21 @@ type ControlAction implements ThingInterface & ActionInterface & ProvenanceEntit
   relatedMatch: ControlAction  @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ##############################################
   ### ProvenanceActivityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#startedAtTime"
+  "http://www.w3.org/ns/prov#startedAtTime"
   startedAtTime: _Neo4jDateTime
-  "https://www.w3.org/TR/prov-o/#wasInformedBy"
+  "http://www.w3.org/ns/prov#wasInformedBy"
   wasInformedBy: [ActionInterface] @relation(name: "WAS_INFORMED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#endedAtTime"
+  "http://www.w3.org/ns/prov#endedAtTime"
   endedAtTime: _Neo4jDateTime
   ##################################
   ### ActionInterface properties ###

--- a/src/schema/type/CreativeWork.graphql
+++ b/src/schema/type/CreativeWork.graphql
@@ -72,13 +72,13 @@ type CreativeWork implements MetadataInterface & SearchableInterface & ThingInte
   relatedMatch: [ThingInterface]  @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###############################
   ### CreativeWork properties ###

--- a/src/schema/type/DataDownload.graphql
+++ b/src/schema/type/DataDownload.graphql
@@ -72,13 +72,13 @@ type DataDownload implements MetadataInterface & SearchableInterface & ThingInte
   relatedMatch: [ThingInterface]  @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###############################
   ### CreativeWork properties ###

--- a/src/schema/type/Dataset.graphql
+++ b/src/schema/type/Dataset.graphql
@@ -72,13 +72,13 @@ type Dataset implements MetadataInterface & SearchableInterface & ThingInterface
   relatedMatch: [ThingInterface] @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###############################
   ### CreativeWork properties ###

--- a/src/schema/type/DeleteAction.graphql
+++ b/src/schema/type/DeleteAction.graphql
@@ -48,10 +48,10 @@ type DeleteAction implements ThingInterface & ActionInterface & ProvenanceEntity
   endedAtTime: _Neo4jDateTime
   ##################################
   ### ActionInterface properties ###
-  #"https://schema.org/actionStatus"
-  #actionStatus: String
+  "https://schema.org/actionStatus"
+  actionStatus: ActionStatusType
   "https://schema.org/agent"
-  agent: [LegalPersonInterface] @relation(name: "AGENT", direction: "OUT")
+  agent: String
   "https://schema.org/endTime"
   endTime: _Neo4jDateTime
   "https://schema.org/error"
@@ -63,7 +63,7 @@ type DeleteAction implements ThingInterface & ActionInterface & ProvenanceEntity
   "https://schema.org/object"
   object: [ThingInterface] @relation(name: "OBJECT", direction: "OUT")
   "https://schema.org/participant"
-  participant: [LegalPersonInterface] @relation(name: "PARTICIPANT", direction: "OUT")
+  participant: [String]
   "https://schema.org/result"
   result: ThingInterface @relation(name: "RESULT", direction: "OUT")
   "https://schema.org/startTime"

--- a/src/schema/type/DeleteAction.graphql
+++ b/src/schema/type/DeleteAction.graphql
@@ -1,4 +1,4 @@
-"https://schema.org/DeleteAction,https://www.w3.org/TR/prov-o/#Activity"
+"https://schema.org/DeleteAction,http://www.w3.org/ns/prov#Activity"
 type DeleteAction implements ThingInterface & ActionInterface & ProvenanceEntityInterface & ProvenanceActivityInterface {
   ########################
   ### ThingInterface properties ###
@@ -30,21 +30,21 @@ type DeleteAction implements ThingInterface & ActionInterface & ProvenanceEntity
   url: URL
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ##############################################
   ### ProvenanceActivityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#startedAtTime"
+  "http://www.w3.org/ns/prov#startedAtTime"
   startedAtTime: _Neo4jDateTime
-  "https://www.w3.org/TR/prov-o/#wasInformedBy"
+  "http://www.w3.org/ns/prov#wasInformedBy"
   wasInformedBy: [ActionInterface] @relation(name: "WAS_INFORMED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#endedAtTime"
+  "http://www.w3.org/ns/prov#endedAtTime"
   endedAtTime: _Neo4jDateTime
   ##################################
   ### ActionInterface properties ###

--- a/src/schema/type/DigitalDocument.graphql
+++ b/src/schema/type/DigitalDocument.graphql
@@ -72,13 +72,13 @@ type DigitalDocument implements MetadataInterface & SearchableInterface & ThingI
   relatedMatch: [ThingInterface]  @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###############################
   ### CreativeWork properties ###

--- a/src/schema/type/DigitalDocumentPermission.graphql
+++ b/src/schema/type/DigitalDocumentPermission.graphql
@@ -42,13 +42,13 @@ type DigitalDocumentPermission implements ThingInterface & ProvenanceEntityInter
   relatedMatch: [ThingInterface]  @relation(name: "RELATED_MATCH", direction: "OUT")
   ######################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ############################################
   ### DigitalDocumentPermission properties ###

--- a/src/schema/type/EntryPoint.graphql
+++ b/src/schema/type/EntryPoint.graphql
@@ -60,13 +60,13 @@ type EntryPoint implements MetadataInterface & ThingInterface & ProvenanceEntity
   url: URL
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ### EntryPoint properties ###
   #############################

--- a/src/schema/type/Event.graphql
+++ b/src/schema/type/Event.graphql
@@ -72,13 +72,13 @@ type Event implements MetadataInterface & SearchableInterface & ThingInterface &
   relatedMatch: [ThingInterface]  @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ########################
   ### Event properties ###

--- a/src/schema/type/ImageObject.graphql
+++ b/src/schema/type/ImageObject.graphql
@@ -72,13 +72,13 @@ type ImageObject implements MetadataInterface & SearchableInterface & ThingInter
   relatedMatch: [ThingInterface] @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###############################
   ### CreativeWork properties ###

--- a/src/schema/type/Intangible.graphql
+++ b/src/schema/type/Intangible.graphql
@@ -72,12 +72,12 @@ type Intangible implements MetadataInterface & SearchableInterface & ThingInterf
   relatedMatch: [ThingInterface]  @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
 }

--- a/src/schema/type/MediaObject.graphql
+++ b/src/schema/type/MediaObject.graphql
@@ -72,13 +72,13 @@ type MediaObject implements MetadataInterface & SearchableInterface & ThingInter
   relatedMatch: [ThingInterface]  @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###############################
   ### CreativeWork properties ###

--- a/src/schema/type/MusicAlbum.graphql
+++ b/src/schema/type/MusicAlbum.graphql
@@ -72,13 +72,13 @@ type MusicAlbum implements MetadataInterface & SearchableInterface & ThingInterf
   relatedMatch: [ThingInterface] @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###############################
   ### CreativeWork properties ###

--- a/src/schema/type/MusicComposition.graphql
+++ b/src/schema/type/MusicComposition.graphql
@@ -72,13 +72,13 @@ type MusicComposition implements MetadataInterface & SearchableInterface & Thing
   relatedMatch: [ThingInterface] @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###############################
   ### CreativeWork properties ###

--- a/src/schema/type/MusicGroup.graphql
+++ b/src/schema/type/MusicGroup.graphql
@@ -72,19 +72,19 @@ type MusicGroup implements MetadataInterface & SearchableInterface & ThingInterf
   relatedMatch: [ThingInterface] @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###########################################
   ### ProvenanceAgentInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasAssociatedWith"
+  "http://www.w3.org/ns/prov#wasAssociatedWith"
   wasAssociatedWith: [LegalPersonInterface] @relation(name: "WAS_ASSOCIATED_WITH", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#actedOnBehalfOf"
+  "http://www.w3.org/ns/prov#actedOnBehalfOf"
   actedOnBehalfOf: [LegalPersonInterface] @relation(name: "ACTED_ON_BEHALF_OF", direction: "OUT")
   ###############################
   ### Organization properties ###

--- a/src/schema/type/MusicPlaylist.graphql
+++ b/src/schema/type/MusicPlaylist.graphql
@@ -72,13 +72,13 @@ type MusicPlaylist implements MetadataInterface & SearchableInterface & ThingInt
   relatedMatch: [ThingInterface] @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###############################
   ### CreativeWork properties ###

--- a/src/schema/type/MusicRecording.graphql
+++ b/src/schema/type/MusicRecording.graphql
@@ -72,13 +72,13 @@ type MusicRecording implements MetadataInterface & SearchableInterface & ThingIn
   relatedMatch: [ThingInterface] @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###############################
   ### CreativeWork properties ###

--- a/src/schema/type/Organization.graphql
+++ b/src/schema/type/Organization.graphql
@@ -1,4 +1,4 @@
-"https://schema.org/Organization,https://www.w3.org/TR/prov-o/#Agent"
+"https://schema.org/Organization,http://www.w3.org/ns/prov#Agent"
 type Organization implements MetadataInterface & SearchableInterface & ThingInterface & ProvenanceEntityInterface & ProvenanceAgentInterface & OrganizationInterface & LegalPersonInterface {
   ### Metadata properties ###
   "http://purl.org/dc/elements/1.1/identifier,https://schema.org/identifier"
@@ -72,19 +72,19 @@ type Organization implements MetadataInterface & SearchableInterface & ThingInte
   relatedMatch: [ThingInterface]  @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###########################################
   ### ProvenanceAgentInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasAssociatedWith"
+  "http://www.w3.org/ns/prov#wasAssociatedWith"
   wasAssociatedWith: [LegalPersonInterface] @relation(name: "WAS_ASSOCIATED_WITH", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#actedOnBehalfOf"
+  "http://www.w3.org/ns/prov#actedOnBehalfOf"
   actedOnBehalfOf: [LegalPersonInterface] @relation(name: "ACTED_ON_BEHALF_OF", direction: "OUT")
   ###############################
   ### Organization properties ###

--- a/src/schema/type/Person.graphql
+++ b/src/schema/type/Person.graphql
@@ -1,4 +1,4 @@
-"https://schema.org/Person,https://www.w3.org/TR/prov-o/#Agent"
+"https://schema.org/Person,http://www.w3.org/ns/prov#Agent"
 type Person implements MetadataInterface & SearchableInterface & ThingInterface & ProvenanceEntityInterface & ProvenanceAgentInterface & LegalPersonInterface & PerformerInterface {
   ### Metadata properties ###
   "http://purl.org/dc/elements/1.1/identifier,https://schema.org/identifier"
@@ -72,19 +72,19 @@ type Person implements MetadataInterface & SearchableInterface & ThingInterface 
   relatedMatch: [ThingInterface] @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###########################################
   ### ProvenanceAgentInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasAssociatedWith"
+  "http://www.w3.org/ns/prov#wasAssociatedWith"
   wasAssociatedWith: [LegalPersonInterface] @relation(name: "WAS_ASSOCIATED_WITH", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#actedOnBehalfOf"
+  "http://www.w3.org/ns/prov#actedOnBehalfOf"
   actedOnBehalfOf: [LegalPersonInterface] @relation(name: "ACTED_ON_BEHALF_OF", direction: "OUT")
   #########################
   ### Person properties ###

--- a/src/schema/type/Place.graphql
+++ b/src/schema/type/Place.graphql
@@ -72,13 +72,13 @@ type Place implements MetadataInterface & SearchableInterface & ThingInterface &
   relatedMatch: [ThingInterface]  @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ########################
   ### Place properties ###

--- a/src/schema/type/Product.graphql
+++ b/src/schema/type/Product.graphql
@@ -72,13 +72,13 @@ type Product implements MetadataInterface & SearchableInterface & ThingInterface
   relatedMatch: [ThingInterface]  @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ##########################
   ### Product properties ###

--- a/src/schema/type/ReplaceAction.graphql
+++ b/src/schema/type/ReplaceAction.graphql
@@ -48,10 +48,10 @@ type ReplaceAction implements ThingInterface & ActionInterface & ProvenanceEntit
   endedAtTime: _Neo4jDateTime
   ##################################
   ### ActionInterface properties ###
-  #"https://schema.org/actionStatus"
-  #actionStatus: String
+  "https://schema.org/actionStatus"
+  actionStatus: ActionStatusType
   "https://schema.org/agent"
-  agent: [LegalPersonInterface] @relation(name: "AGENT", direction: "OUT")
+  agent: String
   "https://schema.org/endTime"
   endTime: _Neo4jDateTime
   "https://schema.org/error"
@@ -63,7 +63,7 @@ type ReplaceAction implements ThingInterface & ActionInterface & ProvenanceEntit
   "https://schema.org/object"
   object: [ThingInterface] @relation(name: "OBJECT", direction: "OUT")
   "https://schema.org/participant"
-  participant: [LegalPersonInterface] @relation(name: "PARTICIPANT", direction: "OUT")
+  participant: [String]
   "https://schema.org/result"
   result: ThingInterface @relation(name: "RESULT", direction: "OUT")
   "https://schema.org/startTime"

--- a/src/schema/type/ReplaceAction.graphql
+++ b/src/schema/type/ReplaceAction.graphql
@@ -1,4 +1,4 @@
-"https://schema.org/ReplaceAction,https://www.w3.org/TR/prov-o/#Activity"
+"https://schema.org/ReplaceAction,http://www.w3.org/ns/prov#Activity"
 type ReplaceAction implements ThingInterface & ActionInterface & ProvenanceEntityInterface & ProvenanceActivityInterface {
   ########################
   ### ThingInterface properties ###
@@ -30,21 +30,21 @@ type ReplaceAction implements ThingInterface & ActionInterface & ProvenanceEntit
   url: URL
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ##############################################
   ### ProvenanceActivityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#startedAtTime"
+  "http://www.w3.org/ns/prov#startedAtTime"
   startedAtTime: _Neo4jDateTime
-  "https://www.w3.org/TR/prov-o/#wasInformedBy"
+  "http://www.w3.org/ns/prov#wasInformedBy"
   wasInformedBy: [ActionInterface] @relation(name: "WAS_INFORMED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#endedAtTime"
+  "http://www.w3.org/ns/prov#endedAtTime"
   endedAtTime: _Neo4jDateTime
   ##################################
   ### ActionInterface properties ###

--- a/src/schema/type/Review.graphql
+++ b/src/schema/type/Review.graphql
@@ -72,13 +72,13 @@ type Review implements MetadataInterface & SearchableInterface & ThingInterface 
   relatedMatch: [ThingInterface] @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###############################
   ### CreativeWork properties ###

--- a/src/schema/type/SoftwareApplication.graphql
+++ b/src/schema/type/SoftwareApplication.graphql
@@ -72,13 +72,13 @@ type SoftwareApplication implements MetadataInterface & SearchableInterface & Th
   relatedMatch: [ThingInterface]  @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###############################
   ### CreativeWork properties ###

--- a/src/schema/type/VideoObject.graphql
+++ b/src/schema/type/VideoObject.graphql
@@ -72,13 +72,13 @@ type VideoObject implements MetadataInterface & SearchableInterface & ThingInter
   relatedMatch: [ThingInterface] @relation(name: "RELATED_MATCH", direction: "OUT")
   ############################################
   ### ProvenanceEntityInterface properties ###
-  "https://www.w3.org/TR/prov-o/#wasGeneratedBy"
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
   wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasDerivedFrom"
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#wasAttributedTo"
+  "http://www.w3.org/ns/prov#wasAttributedTo"
   wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: "OUT")
-  "https://www.w3.org/TR/prov-o/#used"
+  "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: "OUT")
   ###############################
   ### CreativeWork properties ###


### PR DESCRIPTION
**Todo**

- [x] Fix the JSON-LD context URIs reported by @musicog via Slack

As discussed on Slack, this PR modifies the ControlActions `agent` and `participant` fields to String types in order to assign these tasks to users with a username or WebID.

Given a ControlAction with the following data (stripped version):

```json
{
    "agent": "MozartLover115",
    "endedAtTime": null,
    "description": null,
    "wasDerivedFrom": [],
    "participant": [
        "Anonymous",
        "https://trompamusic.eu#user1234"
    ],
    "identifier": "d6bfd36b-c40b-44e5-9c6f-a6219a0050b3"
}
```

Will produce the following JSON-LD repsonse:

```json
{
    "@context": [
        "https://schema.org/",
        {
            "dc": "http://purl.org/dc/elements/1.1/",
            "prov": "https://www.w3.org/TR/prov-o/#",
            "skos": "http://www.w3.org/2004/02/skos/core#",
            "rdf": "https://www.w3.org/2000/01/rdf-schema"
        }
    ],
    "@type": [
        "https://schema.org/ControlAction",
        "https://www.w3.org/TR/prov-o/#Activity"
    ],
    "agent": {
        "@type": "Person",
        "callSign": "MozartLover115"
    },
    "prov:endedAtTime": null,
    "dc:description": null,
    "description": null,
    "prov:wasDerivedFrom": [],
    "subjectOf": [],
    "instrument": [],
    "prov:used": [],
    "mainEntityOfPage": [],
    "error": null,
    "participant": [
        {
            "@type": "Person",
            "callSign": "Anonymous"
        },
        {
            "@type": "Person",
            "url": "https://trompamusic.eu#user1234"
        }
    ],
    "result": null
}
```

For the Orchestra use-case, we can now assign ControlActions to users and filter out already assigned ControlActions.