### PR TITLE
feat(schema): allow creator and endTime properties in RequestControlAction

### DIFF
--- a/src/commands/RequestControlActionCommand.js
+++ b/src/commands/RequestControlActionCommand.js
@@ -207,6 +207,10 @@ class RequestControlActionCommand {
         return (typeof properties[key] !== 'object' && !['identifier', '_schemaType'].includes(key))
       })
       .map(key => {
+        if (key === 'endTime') {
+          return `\`${key}\`: datetime("${potentialActionProps[key] || properties[key]}")`
+        }
+
         return `\`${key}\`:"${potentialActionProps[key] || properties[key]}"`
       })
       .join(', ')

--- a/src/schema/input.graphql
+++ b/src/schema/input.graphql
@@ -11,6 +11,8 @@ input PotentialActionInput {
   title: String
   description: String
   url: String
+  creator: String
+  endTime: String
 }
 
 input PropertyValueInput {


### PR DESCRIPTION
```graphql
mutation {
	RequestControlAction(
		controlAction: {
			entryPointIdentifier: "e63fc3c5-f84e-4a64-9d5b-98a49dd4680c"
			potentialActionIdentifier: "b559c52d-6104-4cb3-ab82-39b82bb2de6c"
			potentialAction: {
				name: "Verify Measures in Beethoven’s 32 Variations"
				description: "Within the TROMPA pqroject, we have the vision that more hands will make for lighter work in digitizing and enriching digital music. As an illustration of this vision, here is an example of a running campaign, in which you would be asked to verify whether the musical content in two given measures is the same or not. Can you spot any errors?"
			        url: "https://trompa-campaign-manager.netlify.com",
                                creator: "Christiaan",
                                endTime: "2020-11-12T05:36:23Z"
			}
			propertyObject: [
				{
					potentialActionPropertyIdentifier: "52abfac4-385e-4a31-8f1d-9572f3c9b6b0"
					nodeIdentifier: "fd754306-53dc-461e-97b3-1afd923a55b1"
					nodeType: DigitalDocument
				}
			]
			propertyValueObject: [
				{
					potentialActionPropertyValueSpecificationIdentifier: "cbf412a5-ea6e-44df-b84f-5ad4d0647e1f"
					valuePattern: String
					value: "9a13c04d-bd87-45d1-b13a-c2730e69ca8c"
				}
			]
		}
	) {
		identifier
	}
}
```