### PR TITLE
copy name field from Property to PropertyValue when using RequestControlAction

### DIFF
--- a/src/commands/RequestControlActionCommand.js
+++ b/src/commands/RequestControlActionCommand.js
@@ -227,7 +227,7 @@ class RequestControlActionCommand {
       `\`propertyID\`:"${templateProperty.identifier}"`,
       `\`description\`:"${templateProperty.description}"`,
       `\`title\`:"${templateProperty.title}"`,
-      `\`name\`:"${templateProperty.title}"`,
+      `\`name\`:"${templateProperty.name}"`,
       `\`valueReference\`:"${requestProperty.nodeType}"`
     ]
 


### PR DESCRIPTION
Fixes part of #128

PropertyValue.name was incorrectly being set to Property.title.

Still pending is to add wasDerivedFrom to PropertyValue linking to either a Property or a PropertyValueSpecification

⚠️  This change will require updates in all downstream software that queries PropertyValue.name, for example https://github.com/trompamusic/ce-poc-algorithm/blob/1509d3add3c5ec33f9541618ba9fad9c6266c997/algorithm/src/index.js#L352-L353