### PR TITLE
Add EXAMPLE_OF_WORK relations that link directly to Audio/MediaObject

### DIFF
--- a/src/schema/type/MusicComposition.graphql
+++ b/src/schema/type/MusicComposition.graphql
@@ -210,6 +210,10 @@ type MusicComposition implements MetadataInterface & SearchableInterface & Thing
   video: [VideoObject] @relation(name: "VIDEO", direction: "OUT")
   "https://schema.org/workExample"
   workExample: [CreativeWorkInterface] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
+  "https://schema.org/workExample"
+  workExampleMediaObject: [MediaObject] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
+  "https://schema.org/workExample"
+  workExampleAudioObject: [AudioObject] @relation(name: "EXAMPLE_OF_WORK", direction: "IN")
   "https://bib.schema.org/workTranslation"
   workTranslation: [CreativeWorkInterface] @relation(name: "WORK_TRANSLATION", direction: "OUT")
   #######################################


### PR DESCRIPTION
⚠️ There's a bug still present, where neo4j-graphql-js doesn't generate filters for custom scalars. As workExample is `URL` not String, it doesn't generate the filter. Perhaps we'll have to switch all URLs back to Strings

Fixes #132 

Because workExample links to CreativeWorkInterface, we can't use the
auto-generated filters to query a more specific type, e.g.:
  MusicComposition(filter:{workExample:{contentUrl_not:null}})
doesn't work because contentUrl is part of MediaObject not CreativeWork.

We add additional fields using the same relation name that point
directly to the concrete types that we use in TROMPA. This means that
the workExample relation still works, but if we need to filter on a
specific Audio/MediaObject field we can. This isn't very sustainable
because we'd have to add it every time we need to do this kind of query
to a specific type, but it's a quick fix for our current requirements

tests:
```
mutation {
  CreateMusicComposition (
    identifier:"e564c7bf-e0de-452a-9d56-d2a98f1a39ed"
    creator:"creator"
    contributor:"contributor"
    source:"http://example.com"
    format:"text/html"
    title:"My composition"
  ) {
    identifier
  }
}
mutation {
  CreateAudioObject (
    identifier:"0c2cedfa-e0cc-4d6a-b828-89110b4a5341"
    creator:"creator"
    contributor:"contributor"
    source:"http://example.com/file.mp3"
    contentUrl:"http://example.com/file.mp3"
    format:"mp3"
    title:"audio file"
  ) {
    identifier
  }
}
mutation {
  CreateMediaObject (
    identifier:"ceb5534d-107d-43e6-a888-b73c8be65b57"
    creator:"creator"
    contributor:"contributor"
    source:"http://example.com/something.pdf"
    contentUrl:"http://example.com/something.pdf"
    format:"pdf"
    title:"pdf file"
  ) {
    identifier
  }
}
mutation {
  MergeMediaObjectExampleOfWork (
    from:{identifier:"ceb5534d-107d-43e6-a888-b73c8be65b57"}
    to:{identifier:"e564c7bf-e0de-452a-9d56-d2a98f1a39ed"}
  ) {
    from {identifier}
    to {identifier}
  }
}
mutation {
  MergeAudioObjectExampleOfWork (
    from:{identifier:"0c2cedfa-e0cc-4d6a-b828-89110b4a5341"}
    to:{identifier:"e564c7bf-e0de-452a-9d56-d2a98f1a39ed"}
  ) {
    from {identifier}
    to {identifier}
  }
}
```
and some queries:
You can ask for related items using either field, after just adding the relation once:
```
query {
  MusicComposition(identifier:"e564c7bf-e0de-452a-9d56-d2a98f1a39ed") {
    title
    workExample {
      ... on MediaObject {
        title
        contentUrl
      }
      ... on AudioObject {
        title
        contentUrl
      }
    }
    workExampleMediaObject {
      contentUrl
    }
    workExampleAudioObject {
      contentUrl
    }
  }
}

--> result

{
  "data": {
    "MusicComposition": [
      {
        "title": "My composition",
        "workExample": [
          {
            "title": "audio file",
            "contentUrl": "http://example.com/afile.mp3"
          },
          {
            "title": "pdf file",
            "contentUrl": "http://example.com/something.pdf"
          }
        ],
        "workExampleMediaObject": [
          {
            "contentUrl": "http://example.com/something.pdf"
          }
        ],
        "workExampleAudioObject": [
          {
            "contentUrl": "http://example.com/afile.mp3"
          }
        ]
      }
    ]
  }
}
```

Query for contentUrl against the workExample field results in an error:
```
query {
  MusicComposition(filter:{workExample:{contentUrl:"http://example.com/something.pdf"}}) {
    title
  }
}
```


Query for contentUrl against workExampleAudioObject succeeds
```
query {
  MusicComposition(filter:{workExampleMediaObject:{contentUrl:"http://example.com/something.pdf"}}) {
    title
  }
}
```

