### PR TITLE
Remove custom URL scalar

### DIFF
--- a/src/schema/enum.graphql
+++ b/src/schema/enum.graphql
@@ -220,7 +220,6 @@ enum ValuePattern {
   Int
   Float
   Boolean
-  URL
   Duration
   _Neo4jDate
   _Neo4jDateTime
@@ -261,7 +260,6 @@ enum ValueReference {
   Int
   Float
   Boolean
-  URL
   Duration
   _Neo4jDate
   _Neo4jDateTime
@@ -312,7 +310,6 @@ enum ValidAdditionalPropertyNodeValueType {
   Int
   Float
   Boolean
-  URL
   Duration
   _Neo4jDate
   _Neo4jDateTime

--- a/src/schema/interface/ActionInterface.graphql
+++ b/src/schema/interface/ActionInterface.graphql
@@ -47,7 +47,7 @@ interface ActionInterface {
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -55,11 +55,11 @@ interface ActionInterface {
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###

--- a/src/schema/interface/CreativeWorkInterface.graphql
+++ b/src/schema/interface/CreativeWorkInterface.graphql
@@ -47,7 +47,7 @@ interface CreativeWorkInterface {
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -55,11 +55,11 @@ interface CreativeWorkInterface {
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -140,7 +140,7 @@ interface CreativeWorkInterface {
   "https://schema.org/keywords"
   keywords: String
   "https://schema.org/license"
-  license: URL
+  license: String
   "https://schema.org/mainEntity"
   mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "OUT")
   "https://schema.org/mentions"
@@ -152,7 +152,7 @@ interface CreativeWorkInterface {
   "https://schema.org/publisher"
   schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
   "https://schema.org/publishingPrinciples"
-  publishingPrinciples: URL
+  publishingPrinciples: String
   "https://schema.org/recordedAt"
   recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
   "https://schema.org/sourceOrganization"
@@ -160,7 +160,7 @@ interface CreativeWorkInterface {
   "https://schema.org/text"
   text: String
   "https://schema.org/thumbnailUrl"
-  thumbnailUrl: URL
+  thumbnailUrl: String
   "https://schema.org/translator"
   translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
   "https://schema.org/version"

--- a/src/schema/interface/LegalPersonInterface.graphql
+++ b/src/schema/interface/LegalPersonInterface.graphql
@@ -46,7 +46,7 @@ interface LegalPersonInterface {
     "https://schema.org/alternateName"
     alternateName: String
     "https://schema.org/image"
-    image: URL
+    image: String
     "https://schema.org/mainEntityOfPage"
     mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
     "https://schema.org/name"
@@ -54,11 +54,11 @@ interface LegalPersonInterface {
     "https://schema.org/potentialAction"
     potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
     "https://schema.org/sameAs"
-    sameAs: URL
+    sameAs: String
     "https://schema.org/subjectOf"
     subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
     "https://schema.org/url"
-    url: URL
+    url: String
 
     #######################
     ### SKOS properties ###

--- a/src/schema/interface/MediaObjectInterface.graphql
+++ b/src/schema/interface/MediaObjectInterface.graphql
@@ -47,7 +47,7 @@ interface MediaObjectInterface {
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -55,11 +55,11 @@ interface MediaObjectInterface {
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -140,7 +140,7 @@ interface MediaObjectInterface {
   "https://schema.org/keywords"
   keywords: String
   "https://schema.org/license"
-  license: URL
+  license: String
   "https://schema.org/mainEntity"
   mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "OUT")
   "https://schema.org/mentions"
@@ -152,7 +152,7 @@ interface MediaObjectInterface {
   "https://schema.org/publisher"
   schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
   "https://schema.org/publishingPrinciples"
-  publishingPrinciples: URL
+  publishingPrinciples: String
   "https://schema.org/recordedAt"
   recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
   "https://schema.org/sourceOrganization"
@@ -160,7 +160,7 @@ interface MediaObjectInterface {
   "https://schema.org/text"
   text: String
   "https://schema.org/thumbnailUrl"
-  thumbnailUrl: URL
+  thumbnailUrl: String
   "https://schema.org/translator"
   translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
   "https://schema.org/version"
@@ -181,11 +181,11 @@ interface MediaObjectInterface {
   "https://schema.org/contentSize"
   contentSize: String
   "https://schema.org/contentUrl"
-  contentUrl: URL
+  contentUrl: String
   "https://schema.org/duration"
   duration: Duration
   "https://schema.org/embedUrl"
-  embedUrl: URL
+  embedUrl: String
   "https://schema.org/encodesCreativeWork"
   encodesCreativeWork: [CreativeWorkInterface] @relation(name: "ENCODES_CREATIVE_WORK", direction: "OUT")
   "https://schema.org/height"

--- a/src/schema/interface/OrganizationInterface.graphql
+++ b/src/schema/interface/OrganizationInterface.graphql
@@ -47,7 +47,7 @@ interface OrganizationInterface {
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -55,11 +55,11 @@ interface OrganizationInterface {
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -141,7 +141,7 @@ interface OrganizationInterface {
   "https://schema.org/location"
   location: [Place] @relation(name: "LOCATION", direction: "IN")
   "https://schema.org/logo"
-  logo: URL
+  logo: String
   #makesOffer
   "https://schema.org/member"
   member: [LegalPersonInterface] @relation(name: "MEMBER", direction: "IN")
@@ -150,12 +150,12 @@ interface OrganizationInterface {
   #naics
   "https://schema.org/numberOfEmployees"
   numberOfEmployees: Int
-  #ownershipFundingInfo: URL
+  #ownershipFundingInfo: String
   #owns
   "https://schema.org/parentOrganization"
   parentOrganization: Organization @relation(name: "PARENT_ORGANIZATION", direction: "IN")
   #"https://schema.org/publishingPrinciples"
-  #publishingPrinciples: URL
+  #publishingPrinciples: String
   "https://schema.org/review"
   review: [Review]
   #seeks
@@ -167,7 +167,7 @@ interface OrganizationInterface {
 #  "https://schema.org/telephone"
 #  telephone: String
   "https://schema.org/unnamedSourcesPolicy"
-  unnamedSourcesPolicy: URL
+  unnamedSourcesPolicy: String
 #  "https://schema.org/vatID"
 #  vatID: String
 }

--- a/src/schema/interface/PerformerInterface.graphql
+++ b/src/schema/interface/PerformerInterface.graphql
@@ -46,7 +46,7 @@ interface PerformerInterface {
     "https://schema.org/alternateName"
     alternateName: String
     "https://schema.org/image"
-    image: URL
+    image: String
     "https://schema.org/mainEntityOfPage"
     mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
     "https://schema.org/name"
@@ -54,11 +54,11 @@ interface PerformerInterface {
     "https://schema.org/potentialAction"
     potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
     "https://schema.org/sameAs"
-    sameAs: URL
+    sameAs: String
     "https://schema.org/subjectOf"
     subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
     "https://schema.org/url"
-    url: URL
+    url: String
 
     #######################
     ### SKOS properties ###

--- a/src/schema/interface/SearchableInterface.graphql
+++ b/src/schema/interface/SearchableInterface.graphql
@@ -14,7 +14,7 @@ interface SearchableInterface {
   "https://schema.org/disambiguatingDescription"
   disambiguatingDescription: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -22,11 +22,11 @@ interface SearchableInterface {
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://pending.schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://pending.schema.org/url"
-  url: URL
+  url: String
 
   ########################
   ### MetadataInterface properties ###

--- a/src/schema/interface/ThingInterface.graphql
+++ b/src/schema/interface/ThingInterface.graphql
@@ -15,7 +15,7 @@ interface ThingInterface {
 "https://schema.org/disambiguatingDescription"
   disambiguatingDescription: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -23,11 +23,11 @@ interface ThingInterface {
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   ########################
   ### MetadataInterface properties ###

--- a/src/schema/scalar.graphql
+++ b/src/schema/scalar.graphql
@@ -1,6 +1,4 @@
 "https://schema.org/Duration"
 scalar Duration
-"https://schema.org/URL"
-scalar URL
 "https://schema.org/value"
 scalar Value

--- a/src/schema/type/Action.graphql
+++ b/src/schema/type/Action.graphql
@@ -51,7 +51,7 @@ type Action implements ThingInterface & ActionInterface & ProvenanceEntityInterf
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type Action implements ThingInterface & ActionInterface & ProvenanceEntityInterf
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###

--- a/src/schema/type/AddAction.graphql
+++ b/src/schema/type/AddAction.graphql
@@ -47,7 +47,7 @@ type AddAction implements ThingInterface & ActionInterface & ProvenanceEntityInt
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -55,11 +55,11 @@ type AddAction implements ThingInterface & ActionInterface & ProvenanceEntityInt
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   ############################################
   ### ProvenanceEntityInterface properties ###

--- a/src/schema/type/Article.graphql
+++ b/src/schema/type/Article.graphql
@@ -51,7 +51,7 @@ type Article implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type Article implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -144,7 +144,7 @@ type Article implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "https://schema.org/keywords"
   keywords: String
   "https://schema.org/license"
-  license: URL
+  license: String
   "https://schema.org/mainEntity"
   mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "OUT")
   "https://schema.org/mentions"
@@ -156,7 +156,7 @@ type Article implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "https://schema.org/publisher"
   schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
   "https://schema.org/publishingPrinciples"
-  publishingPrinciples: URL
+  publishingPrinciples: String
   "https://schema.org/recordedAt"
   recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
   "https://schema.org/sourceOrganization"
@@ -164,7 +164,7 @@ type Article implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "https://schema.org/text"
   text: String
   "https://schema.org/thumbnailUrl"
-  thumbnailUrl: URL
+  thumbnailUrl: String
   "https://schema.org/translator"
   translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
   "https://schema.org/version"

--- a/src/schema/type/Audience.graphql
+++ b/src/schema/type/Audience.graphql
@@ -46,7 +46,7 @@ type Audience implements ThingInterface {
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -54,11 +54,11 @@ type Audience implements ThingInterface {
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
   #######################
   ### SKOS properties ###
   "http://www.w3.org/2004/02/skos/core#broadMatch"

--- a/src/schema/type/AudioObject.graphql
+++ b/src/schema/type/AudioObject.graphql
@@ -51,7 +51,7 @@ type AudioObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type AudioObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -144,7 +144,7 @@ type AudioObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/keywords"
   keywords: String
   "https://schema.org/license"
-  license: URL
+  license: String
   "https://schema.org/mainEntity"
   mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "OUT")
   "https://schema.org/mentions"
@@ -156,7 +156,7 @@ type AudioObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/publisher"
   schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
   "https://schema.org/publishingPrinciples"
-  publishingPrinciples: URL
+  publishingPrinciples: String
   "https://schema.org/recordedAt"
   recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
   "https://schema.org/sourceOrganization"
@@ -164,7 +164,7 @@ type AudioObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/text"
   text: String
   "https://schema.org/thumbnailUrl"
-  thumbnailUrl: URL
+  thumbnailUrl: String
   "https://schema.org/translator"
   translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
   "https://schema.org/version"
@@ -185,11 +185,11 @@ type AudioObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/contentSize"
   contentSize: String
   "https://schema.org/contentUrl"
-  contentUrl: URL
+  contentUrl: String
   "https://schema.org/duration"
   duration: Duration
   "https://schema.org/embedUrl"
-  embedUrl: URL
+  embedUrl: String
   "https://schema.org/encodesCreativeWork"
   encodesCreativeWork: [CreativeWorkInterface] @relation(name: "ENCODES_CREATIVE_WORK", direction: "OUT")
   "https://schema.org/height"

--- a/src/schema/type/ControlAction.graphql
+++ b/src/schema/type/ControlAction.graphql
@@ -47,7 +47,7 @@ type ControlAction implements ThingInterface & ActionInterface & ProvenanceEntit
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -55,11 +55,11 @@ type ControlAction implements ThingInterface & ActionInterface & ProvenanceEntit
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###

--- a/src/schema/type/DataDownload.graphql
+++ b/src/schema/type/DataDownload.graphql
@@ -51,7 +51,7 @@ type DataDownload implements SearchableInterface & ThingInterface & ProvenanceEn
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type DataDownload implements SearchableInterface & ThingInterface & ProvenanceEn
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   ################################
   ### SKOSInterface properties ###
@@ -144,7 +144,7 @@ type DataDownload implements SearchableInterface & ThingInterface & ProvenanceEn
   "https://schema.org/keywords"
   keywords: String
   "https://schema.org/license"
-  license: URL
+  license: String
   "https://schema.org/mainEntity"
   mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "OUT")
   "https://schema.org/mentions"
@@ -156,7 +156,7 @@ type DataDownload implements SearchableInterface & ThingInterface & ProvenanceEn
   "https://schema.org/publisher"
   schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
   "https://schema.org/publishingPrinciples"
-  publishingPrinciples: URL
+  publishingPrinciples: String
   "https://schema.org/recordedAt"
   recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
   "https://schema.org/sourceOrganization"
@@ -164,7 +164,7 @@ type DataDownload implements SearchableInterface & ThingInterface & ProvenanceEn
   "https://schema.org/text"
   text: String
   "https://schema.org/thumbnailUrl"
-  thumbnailUrl: URL
+  thumbnailUrl: String
   "https://schema.org/translator"
   translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
   "https://schema.org/version"
@@ -185,11 +185,11 @@ type DataDownload implements SearchableInterface & ThingInterface & ProvenanceEn
   "https://schema.org/contentSize"
   contentSize: String
   "https://schema.org/contentUrl"
-  contentUrl: URL
+  contentUrl: String
   "https://schema.org/duration"
   duration: Duration
   "https://schema.org/embedUrl"
-  embedUrl: URL
+  embedUrl: String
   "https://schema.org/encodesCreativeWork"
   encodesCreativeWork: [CreativeWorkInterface] @relation(name: "ENCODES_CREATIVE_WORK", direction: "OUT")
   "https://schema.org/height"

--- a/src/schema/type/Dataset.graphql
+++ b/src/schema/type/Dataset.graphql
@@ -51,7 +51,7 @@ type Dataset implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type Dataset implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -144,7 +144,7 @@ type Dataset implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "https://schema.org/keywords"
   keywords: String
   "https://schema.org/license"
-  license: URL
+  license: String
   "https://schema.org/mainEntity"
   mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "OUT")
   "https://schema.org/mentions"
@@ -156,7 +156,7 @@ type Dataset implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "https://schema.org/publisher"
   schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
   "https://schema.org/publishingPrinciples"
-  publishingPrinciples: URL
+  publishingPrinciples: String
   "https://schema.org/recordedAt"
   recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
   "https://schema.org/sourceOrganization"
@@ -164,7 +164,7 @@ type Dataset implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "https://schema.org/text"
   text: String
   "https://schema.org/thumbnailUrl"
-  thumbnailUrl: URL
+  thumbnailUrl: String
   "https://schema.org/translator"
   translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
   "https://schema.org/version"
@@ -185,11 +185,11 @@ type Dataset implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "https://schema.org/contentSize"
   contentSize: String
   "https://schema.org/contentUrl"
-  contentUrl: URL
+  contentUrl: String
   "https://schema.org/duration"
   duration: Duration
   "https://schema.org/embedUrl"
-  embedUrl: URL
+  embedUrl: String
   "https://schema.org/encodesCreativeWork"
   encodesCreativeWork: [CreativeWorkInterface] @relation(name: "ENCODES_CREATIVE_WORK", direction: "OUT")
   "https://schema.org/height"

--- a/src/schema/type/DefinedTerm.graphql
+++ b/src/schema/type/DefinedTerm.graphql
@@ -47,7 +47,7 @@ type DefinedTerm implements ThingInterface {
     "https://schema.org/alternateName"
     alternateName: String
     "https://schema.org/image"
-    image: URL
+    image: String
     "https://schema.org/mainEntityOfPage"
     mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
     "https://schema.org/name"
@@ -55,11 +55,11 @@ type DefinedTerm implements ThingInterface {
     "https://schema.org/potentialAction"
     potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
     "https://schema.org/sameAs"
-    sameAs: URL
+    sameAs: String
     "https://schema.org/subjectOf"
     subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
     "https://schema.org/url"
-    url: URL
+    url: String
 
     ##############################
     ### DefinedTerm properties ###

--- a/src/schema/type/DefinedTermSet.graphql
+++ b/src/schema/type/DefinedTermSet.graphql
@@ -47,7 +47,7 @@ type DefinedTermSet implements CreativeWorkInterface & ThingInterface {
     "https://schema.org/alternateName"
     alternateName: String
     "https://schema.org/image"
-    image: URL
+    image: String
     "https://schema.org/mainEntityOfPage"
     mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
     "https://schema.org/name"
@@ -55,11 +55,11 @@ type DefinedTermSet implements CreativeWorkInterface & ThingInterface {
     "https://schema.org/potentialAction"
     potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
     "https://schema.org/sameAs"
-    sameAs: URL
+    sameAs: String
     "https://schema.org/subjectOf"
     subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
     "https://schema.org/url"
-    url: URL
+    url: String
 
     #######################
     ### SKOS properties ###
@@ -140,7 +140,7 @@ type DefinedTermSet implements CreativeWorkInterface & ThingInterface {
     "https://schema.org/keywords"
     keywords: String
     "https://schema.org/license"
-    license: URL
+    license: String
     "https://schema.org/mainEntity"
     mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "OUT")
     "https://schema.org/mentions"
@@ -152,7 +152,7 @@ type DefinedTermSet implements CreativeWorkInterface & ThingInterface {
     "https://schema.org/publisher"
     schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
     "https://schema.org/publishingPrinciples"
-    publishingPrinciples: URL
+    publishingPrinciples: String
     "https://schema.org/recordedAt"
     recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
     "https://schema.org/sourceOrganization"
@@ -160,7 +160,7 @@ type DefinedTermSet implements CreativeWorkInterface & ThingInterface {
     "https://schema.org/text"
     text: String
     "https://schema.org/thumbnailUrl"
-    thumbnailUrl: URL
+    thumbnailUrl: String
     "https://schema.org/translator"
     translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
     "https://schema.org/version"

--- a/src/schema/type/DeleteAction.graphql
+++ b/src/schema/type/DeleteAction.graphql
@@ -15,7 +15,7 @@ type DeleteAction implements ThingInterface & ActionInterface & ProvenanceEntity
   "https://schema.org/disambiguatingDescription"
   disambiguatingDescription: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -23,11 +23,11 @@ type DeleteAction implements ThingInterface & ActionInterface & ProvenanceEntity
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://pending.schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://pending.schema.org/url"
-  url: URL
+  url: String
 
   ########################
   ### MetadataInterface properties ###

--- a/src/schema/type/DigitalDocument.graphql
+++ b/src/schema/type/DigitalDocument.graphql
@@ -51,7 +51,7 @@ type DigitalDocument implements SearchableInterface & ThingInterface & Provenanc
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type DigitalDocument implements SearchableInterface & ThingInterface & Provenanc
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -144,7 +144,7 @@ type DigitalDocument implements SearchableInterface & ThingInterface & Provenanc
   "https://schema.org/keywords"
   keywords: String
   "https://schema.org/license"
-  license: URL
+  license: String
   "https://schema.org/mainEntity"
   mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "OUT")
   "https://schema.org/mentions"
@@ -156,7 +156,7 @@ type DigitalDocument implements SearchableInterface & ThingInterface & Provenanc
   "https://schema.org/publisher"
   schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
   "https://schema.org/publishingPrinciples"
-  publishingPrinciples: URL
+  publishingPrinciples: String
   "https://schema.org/recordedAt"
   recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
   "https://schema.org/sourceOrganization"
@@ -164,7 +164,7 @@ type DigitalDocument implements SearchableInterface & ThingInterface & Provenanc
   "https://schema.org/text"
   text: String
   "https://schema.org/thumbnailUrl"
-  thumbnailUrl: URL
+  thumbnailUrl: String
   "https://schema.org/translator"
   translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
   "https://schema.org/version"

--- a/src/schema/type/DigitalDocumentPermission.graphql
+++ b/src/schema/type/DigitalDocumentPermission.graphql
@@ -47,7 +47,7 @@ type DigitalDocumentPermission implements ThingInterface & ProvenanceEntityInter
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -55,11 +55,11 @@ type DigitalDocumentPermission implements ThingInterface & ProvenanceEntityInter
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###

--- a/src/schema/type/EntryPoint.graphql
+++ b/src/schema/type/EntryPoint.graphql
@@ -51,7 +51,7 @@ type EntryPoint implements ThingInterface & ProvenanceEntityInterface {
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/disambiguatingDescription"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type EntryPoint implements ThingInterface & ProvenanceEntityInterface {
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   ############################################
   ### ProvenanceEntityInterface properties ###

--- a/src/schema/type/Event.graphql
+++ b/src/schema/type/Event.graphql
@@ -51,7 +51,7 @@ type Event implements SearchableInterface & ThingInterface & ProvenanceEntityInt
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type Event implements SearchableInterface & ThingInterface & ProvenanceEntityInt
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###

--- a/src/schema/type/ImageObject.graphql
+++ b/src/schema/type/ImageObject.graphql
@@ -51,7 +51,7 @@ type ImageObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type ImageObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -144,7 +144,7 @@ type ImageObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/keywords"
   keywords: String
   "https://schema.org/license"
-  license: URL
+  license: String
   "https://schema.org/mainEntity"
   mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "OUT")
   "https://schema.org/mentions"
@@ -156,7 +156,7 @@ type ImageObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/publisher"
   schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
   "https://schema.org/publishingPrinciples"
-  publishingPrinciples: URL
+  publishingPrinciples: String
   "https://schema.org/recordedAt"
   recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
   "https://schema.org/sourceOrganization"
@@ -164,7 +164,7 @@ type ImageObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/text"
   text: String
   "https://schema.org/thumbnailUrl"
-  thumbnailUrl: URL
+  thumbnailUrl: String
   "https://schema.org/translator"
   translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
   "https://schema.org/version"
@@ -185,11 +185,11 @@ type ImageObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/contentSize"
   contentSize: String
   "https://schema.org/contentUrl"
-  contentUrl: URL
+  contentUrl: String
   "https://schema.org/duration"
   duration: Duration
   "https://schema.org/embedUrl"
-  embedUrl: URL
+  embedUrl: String
   "https://schema.org/encodesCreativeWork"
   encodesCreativeWork: [CreativeWorkInterface] @relation(name: "ENCODES_CREATIVE_WORK", direction: "OUT")
   "https://schema.org/height"

--- a/src/schema/type/Intangible.graphql
+++ b/src/schema/type/Intangible.graphql
@@ -49,7 +49,7 @@ type Intangible implements SearchableInterface & ThingInterface & ProvenanceEnti
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -57,11 +57,11 @@ type Intangible implements SearchableInterface & ThingInterface & ProvenanceEnti
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###

--- a/src/schema/type/ItemList.graphql
+++ b/src/schema/type/ItemList.graphql
@@ -47,7 +47,7 @@ type ItemList implements ThingInterface {
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -55,11 +55,11 @@ type ItemList implements ThingInterface {
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   ################################
   ### ItemList properties ###

--- a/src/schema/type/ListItem.graphql
+++ b/src/schema/type/ListItem.graphql
@@ -47,7 +47,7 @@ type ListItem implements ThingInterface {
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -55,11 +55,11 @@ type ListItem implements ThingInterface {
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   ################################
   ### ListItem properties ###

--- a/src/schema/type/MediaObject.graphql
+++ b/src/schema/type/MediaObject.graphql
@@ -51,7 +51,7 @@ type MediaObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type MediaObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -144,7 +144,7 @@ type MediaObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/keywords"
   keywords: String
   "https://schema.org/license"
-  license: URL
+  license: String
   "https://schema.org/mainEntity"
   mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "OUT")
   "https://schema.org/mentions"
@@ -156,7 +156,7 @@ type MediaObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/publisher"
   schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
   "https://schema.org/publishingPrinciples"
-  publishingPrinciples: URL
+  publishingPrinciples: String
   "https://schema.org/recordedAt"
   recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
   "https://schema.org/sourceOrganization"
@@ -164,7 +164,7 @@ type MediaObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/text"
   text: String
   "https://schema.org/thumbnailUrl"
-  thumbnailUrl: URL
+  thumbnailUrl: String
   "https://schema.org/translator"
   translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
   "https://schema.org/version"
@@ -185,11 +185,11 @@ type MediaObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/contentSize"
   contentSize: String
   "https://schema.org/contentUrl"
-  contentUrl: URL
+  contentUrl: String
   "https://schema.org/duration"
   duration: Duration
   "https://schema.org/embedUrl"
-  embedUrl: URL
+  embedUrl: String
   "https://schema.org/encodesCreativeWork"
   encodesCreativeWork: [CreativeWorkInterface] @relation(name: "ENCODES_CREATIVE_WORK", direction: "OUT")
   "https://schema.org/height"

--- a/src/schema/type/MusicAlbum.graphql
+++ b/src/schema/type/MusicAlbum.graphql
@@ -51,7 +51,7 @@ type MusicAlbum implements SearchableInterface & ThingInterface & ProvenanceEnti
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type MusicAlbum implements SearchableInterface & ThingInterface & ProvenanceEnti
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -144,7 +144,7 @@ type MusicAlbum implements SearchableInterface & ThingInterface & ProvenanceEnti
   "https://schema.org/keywords"
   keywords: String
   "https://schema.org/license"
-  license: URL
+  license: String
   "https://schema.org/mainEntity"
   mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "OUT")
   "https://schema.org/mentions"
@@ -156,7 +156,7 @@ type MusicAlbum implements SearchableInterface & ThingInterface & ProvenanceEnti
   "https://schema.org/publisher"
   schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
   "https://schema.org/publishingPrinciples"
-  publishingPrinciples: URL
+  publishingPrinciples: String
   "https://schema.org/recordedAt"
   recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
   "https://schema.org/sourceOrganization"
@@ -164,7 +164,7 @@ type MusicAlbum implements SearchableInterface & ThingInterface & ProvenanceEnti
   "https://schema.org/text"
   text: String
   "https://schema.org/thumbnailUrl"
-  thumbnailUrl: URL
+  thumbnailUrl: String
   "https://schema.org/translator"
   translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
   "https://schema.org/version"
@@ -185,11 +185,11 @@ type MusicAlbum implements SearchableInterface & ThingInterface & ProvenanceEnti
   "https://schema.org/contentSize"
   contentSize: String
   "https://schema.org/contentUrl"
-  contentUrl: URL
+  contentUrl: String
   "https://schema.org/duration"
   duration: Duration
   "https://schema.org/embedUrl"
-  embedUrl: URL
+  embedUrl: String
   "https://schema.org/encodesCreativeWork"
   encodesCreativeWork: [CreativeWorkInterface] @relation(name: "ENCODES_CREATIVE_WORK", direction: "OUT")
   "https://schema.org/height"

--- a/src/schema/type/MusicComposition.graphql
+++ b/src/schema/type/MusicComposition.graphql
@@ -51,7 +51,7 @@ type MusicComposition implements SearchableInterface & ThingInterface & Provenan
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type MusicComposition implements SearchableInterface & ThingInterface & Provenan
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   ################################
   ### SKOSInterface properties ###
@@ -144,7 +144,7 @@ type MusicComposition implements SearchableInterface & ThingInterface & Provenan
   "https://schema.org/keywords"
   keywords: String
   "https://schema.org/license"
-  license: URL
+  license: String
   "https://schema.org/mainEntity"
   mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "OUT")
   "https://schema.org/mentions"
@@ -156,7 +156,7 @@ type MusicComposition implements SearchableInterface & ThingInterface & Provenan
   "https://schema.org/publisher"
   schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
   "https://schema.org/publishingPrinciples"
-  publishingPrinciples: URL
+  publishingPrinciples: String
   "https://schema.org/recordedAt"
   recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
   "https://schema.org/sourceOrganization"
@@ -164,7 +164,7 @@ type MusicComposition implements SearchableInterface & ThingInterface & Provenan
   "https://schema.org/text"
   text: String
   "https://schema.org/thumbnailUrl"
-  thumbnailUrl: URL
+  thumbnailUrl: String
   "https://schema.org/translator"
   translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
   "https://schema.org/version"
@@ -185,11 +185,11 @@ type MusicComposition implements SearchableInterface & ThingInterface & Provenan
   "https://schema.org/contentSize"
   contentSize: String
   "https://schema.org/contentUrl"
-  contentUrl: URL
+  contentUrl: String
   "https://schema.org/duration"
   duration: Duration
   "https://schema.org/embedUrl"
-  embedUrl: URL
+  embedUrl: String
   "https://schema.org/encodesCreativeWork"
   encodesCreativeWork: [CreativeWorkInterface] @relation(name: "ENCODES_CREATIVE_WORK", direction: "OUT")
   "https://schema.org/height"

--- a/src/schema/type/MusicGroup.graphql
+++ b/src/schema/type/MusicGroup.graphql
@@ -51,7 +51,7 @@ type MusicGroup implements SearchableInterface & ThingInterface & ProvenanceEnti
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type MusicGroup implements SearchableInterface & ThingInterface & ProvenanceEnti
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -147,7 +147,7 @@ type MusicGroup implements SearchableInterface & ThingInterface & ProvenanceEnti
   "https://schema.org/location"
   location: [Place] @relation(name: "LOCATION", direction: "IN")
   "https://schema.org/logo"
-  logo: URL
+  logo: String
   #makesOffer
   "https://schema.org/member"
   member: [LegalPersonInterface] @relation(name: "MEMBER", direction: "IN")
@@ -156,12 +156,12 @@ type MusicGroup implements SearchableInterface & ThingInterface & ProvenanceEnti
   #naics
   "https://schema.org/numberOfEmployees"
   numberOfEmployees: Int
-  #ownershipFundingInfo: URL
+  #ownershipFundingInfo: String
   #owns
   "https://schema.org/parentOrganization"
   parentOrganization: Organization @relation(name: "PARENT_ORGANIZATION", direction: "IN")
   #"https://schema.org/publishingPrinciples"
-  #publishingPrinciples: URL
+  #publishingPrinciples: String
   "https://schema.org/review"
   review: [Review]
   #seeks
@@ -173,7 +173,7 @@ type MusicGroup implements SearchableInterface & ThingInterface & ProvenanceEnti
   "https://schema.org/telephone"
   telephone: String
   "https://schema.org/unnamedSourcesPolicy"
-  unnamedSourcesPolicy: URL
+  unnamedSourcesPolicy: String
   "https://schema.org/vatID"
   vatID: String
   #############################

--- a/src/schema/type/MusicPlaylist.graphql
+++ b/src/schema/type/MusicPlaylist.graphql
@@ -51,7 +51,7 @@ type MusicPlaylist implements SearchableInterface & ThingInterface & ProvenanceE
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type MusicPlaylist implements SearchableInterface & ThingInterface & ProvenanceE
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -144,7 +144,7 @@ type MusicPlaylist implements SearchableInterface & ThingInterface & ProvenanceE
   "https://schema.org/keywords"
   keywords: String
   "https://schema.org/license"
-  license: URL
+  license: String
   "https://schema.org/mainEntity"
   mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "OUT")
   "https://schema.org/mentions"
@@ -156,7 +156,7 @@ type MusicPlaylist implements SearchableInterface & ThingInterface & ProvenanceE
   "https://schema.org/publisher"
   schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
   "https://schema.org/publishingPrinciples"
-  publishingPrinciples: URL
+  publishingPrinciples: String
   "https://schema.org/recordedAt"
   recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
   "https://schema.org/sourceOrganization"
@@ -164,7 +164,7 @@ type MusicPlaylist implements SearchableInterface & ThingInterface & ProvenanceE
   "https://schema.org/text"
   text: String
   "https://schema.org/thumbnailUrl"
-  thumbnailUrl: URL
+  thumbnailUrl: String
   "https://schema.org/translator"
   translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
   "https://schema.org/version"
@@ -185,11 +185,11 @@ type MusicPlaylist implements SearchableInterface & ThingInterface & ProvenanceE
   "https://schema.org/contentSize"
   contentSize: String
   "https://schema.org/contentUrl"
-  contentUrl: URL
+  contentUrl: String
   "https://schema.org/duration"
   duration: Duration
   "https://schema.org/embedUrl"
-  embedUrl: URL
+  embedUrl: String
   "https://schema.org/encodesCreativeWork"
   encodesCreativeWork: [CreativeWorkInterface] @relation(name: "ENCODES_CREATIVE_WORK", direction: "OUT")
   "https://schema.org/height"

--- a/src/schema/type/MusicRecording.graphql
+++ b/src/schema/type/MusicRecording.graphql
@@ -51,7 +51,7 @@ type MusicRecording implements SearchableInterface & ThingInterface & Provenance
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type MusicRecording implements SearchableInterface & ThingInterface & Provenance
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -144,7 +144,7 @@ type MusicRecording implements SearchableInterface & ThingInterface & Provenance
   "https://schema.org/keywords"
   keywords: String
   "https://schema.org/license"
-  license: URL
+  license: String
   "https://schema.org/mainEntity"
   mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "OUT")
   "https://schema.org/mentions"
@@ -156,7 +156,7 @@ type MusicRecording implements SearchableInterface & ThingInterface & Provenance
   "https://schema.org/publisher"
   schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
   "https://schema.org/publishingPrinciples"
-  publishingPrinciples: URL
+  publishingPrinciples: String
   "https://schema.org/recordedAt"
   recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
   "https://schema.org/sourceOrganization"
@@ -164,7 +164,7 @@ type MusicRecording implements SearchableInterface & ThingInterface & Provenance
   "https://schema.org/text"
   text: String
   "https://schema.org/thumbnailUrl"
-  thumbnailUrl: URL
+  thumbnailUrl: String
   "https://schema.org/translator"
   translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
   "https://schema.org/version"
@@ -185,11 +185,11 @@ type MusicRecording implements SearchableInterface & ThingInterface & Provenance
   "https://schema.org/contentSize"
   contentSize: String
   "https://schema.org/contentUrl"
-  contentUrl: URL
+  contentUrl: String
   "https://schema.org/duration"
   duration: Duration
   "https://schema.org/embedUrl"
-  embedUrl: URL
+  embedUrl: String
   "https://schema.org/encodesCreativeWork"
   encodesCreativeWork: [CreativeWorkInterface] @relation(name: "ENCODES_CREATIVE_WORK", direction: "OUT")
   "https://schema.org/height"

--- a/src/schema/type/Occupation.graphql
+++ b/src/schema/type/Occupation.graphql
@@ -47,7 +47,7 @@ type Occupation implements ThingInterface {
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -55,11 +55,11 @@ type Occupation implements ThingInterface {
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###

--- a/src/schema/type/Organization.graphql
+++ b/src/schema/type/Organization.graphql
@@ -51,7 +51,7 @@ type Organization implements SearchableInterface & ThingInterface & ProvenanceEn
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type Organization implements SearchableInterface & ThingInterface & ProvenanceEn
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -147,7 +147,7 @@ type Organization implements SearchableInterface & ThingInterface & ProvenanceEn
   "https://schema.org/location"
   location: [Place] @relation(name: "LOCATION", direction: "IN")
   "https://schema.org/logo"
-  logo: URL
+  logo: String
   #makesOffer
   "https://schema.org/member"
   member: [LegalPersonInterface] @relation(name: "MEMBER", direction: "IN")
@@ -156,12 +156,12 @@ type Organization implements SearchableInterface & ThingInterface & ProvenanceEn
   #naics
   "https://schema.org/numberOfEmployees"
   numberOfEmployees: Int
-  #ownershipFundingInfo: URL
+  #ownershipFundingInfo: String
   #owns
   "https://schema.org/parentOrganization"
   parentOrganization: Organization @relation(name: "PARENT_ORGANIZATION", direction: "IN")
   #"https://schema.org/publishingPrinciples"
-  #publishingPrinciples: URL
+  #publishingPrinciples: String
   "https://schema.org/review"
   review: [Review]
   #seeks
@@ -173,7 +173,7 @@ type Organization implements SearchableInterface & ThingInterface & ProvenanceEn
   "https://schema.org/telephone"
   telephone: String
   "https://schema.org/unnamedSourcesPolicy"
-  unnamedSourcesPolicy: URL
+  unnamedSourcesPolicy: String
   "https://schema.org/vatID"
   vatID: String
 }

--- a/src/schema/type/Person.graphql
+++ b/src/schema/type/Person.graphql
@@ -51,7 +51,7 @@ type Person implements SearchableInterface & ThingInterface & ProvenanceEntityIn
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type Person implements SearchableInterface & ThingInterface & ProvenanceEntityIn
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -172,7 +172,7 @@ type Person implements SearchableInterface & ThingInterface & ProvenanceEntityIn
   parent: [Person] @relation(name: "PARENT", direction: "OUT")
   "https://schema.org/performerIn"
   performerIn: [Event] @relation(name: "PERFORMER_IN", direction: "OUT")
-  #publishingPrinciples: URL
+  #publishingPrinciples: String
   "https://schema.org/relatedTo"
   relatedTo: [Person] @relation(name: "RELATED_TO", direction: "OUT")
   #seeks

--- a/src/schema/type/Place.graphql
+++ b/src/schema/type/Place.graphql
@@ -51,7 +51,7 @@ type Place implements SearchableInterface & ThingInterface & ProvenanceEntityInt
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type Place implements SearchableInterface & ThingInterface & ProvenanceEntityInt
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -116,12 +116,12 @@ type Place implements SearchableInterface & ThingInterface & ProvenanceEntityInt
   #geospatiallyWithin: Place
   #globalLocationNumber: String
   "https://schema.org/hasMap"
-  hasMap: URL
+  hasMap: String
   "https://schema.org/isAccessibleForFree"
   isAccessibleForFree: Boolean
   #isicV4
   "https://schema.org/logo"
-  logo: URL
+  logo: String
   "https://schema.org/maximumAttendeeCapacity"
   maximumAttendeeCapacity: Int
   #openingHoursSpecification: openingHoursSpecification

--- a/src/schema/type/Product.graphql
+++ b/src/schema/type/Product.graphql
@@ -51,7 +51,7 @@ type Product implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type Product implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -115,7 +115,7 @@ type Product implements SearchableInterface & ThingInterface & ProvenanceEntityI
   isSimilarTo: [Product] @relation(name: "IS_SIMILAR_TO", direction: "OUT")
   #itemCondition
   "https://schema.org/logo"
-  logo: URL
+  logo: String
   "https://schema.org/manufacturer"
   manufacturer: [Organization] @relation(name: "MANUFACTURER", direction: "OUT")
   "https://schema.org/material"

--- a/src/schema/type/Property.graphql
+++ b/src/schema/type/Property.graphql
@@ -47,7 +47,7 @@ type Property implements ThingInterface {
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -55,11 +55,11 @@ type Property implements ThingInterface {
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   ################################
   ### Property properties ###

--- a/src/schema/type/PropertyValue.graphql
+++ b/src/schema/type/PropertyValue.graphql
@@ -47,7 +47,7 @@ type PropertyValue implements ThingInterface {
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -55,11 +55,11 @@ type PropertyValue implements ThingInterface {
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   ################################
   ### PropertyValue properties ###

--- a/src/schema/type/PropertyValueSpecification.graphql
+++ b/src/schema/type/PropertyValueSpecification.graphql
@@ -47,7 +47,7 @@ type PropertyValueSpecification implements ThingInterface {
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -55,11 +55,11 @@ type PropertyValueSpecification implements ThingInterface {
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   ################################
   ### PropertyValueSpecification properties ###

--- a/src/schema/type/Rating.graphql
+++ b/src/schema/type/Rating.graphql
@@ -47,7 +47,7 @@ type Rating implements ThingInterface {
     "https://schema.org/alternateName"
     alternateName: String
     "https://schema.org/image"
-    image: URL
+    image: String
     "https://schema.org/mainEntityOfPage"
     mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
     "https://schema.org/name"
@@ -55,11 +55,11 @@ type Rating implements ThingInterface {
     "https://schema.org/potentialAction"
     potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
     "https://schema.org/sameAs"
-    sameAs: URL
+    sameAs: String
     "https://schema.org/subjectOf"
     subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
     "https://schema.org/url"
-    url: URL
+    url: String
 
     #########################
     ### Rating properties ###

--- a/src/schema/type/ReplaceAction.graphql
+++ b/src/schema/type/ReplaceAction.graphql
@@ -47,7 +47,7 @@ type ReplaceAction implements ThingInterface & ActionInterface & ProvenanceEntit
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -55,11 +55,11 @@ type ReplaceAction implements ThingInterface & ActionInterface & ProvenanceEntit
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###

--- a/src/schema/type/Review.graphql
+++ b/src/schema/type/Review.graphql
@@ -51,7 +51,7 @@ type Review implements SearchableInterface & ThingInterface & ProvenanceEntityIn
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type Review implements SearchableInterface & ThingInterface & ProvenanceEntityIn
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -144,7 +144,7 @@ type Review implements SearchableInterface & ThingInterface & ProvenanceEntityIn
   "https://schema.org/keywords"
   keywords: String
   "https://schema.org/license"
-  license: URL
+  license: String
   "https://schema.org/mainEntity"
   mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "OUT")
   "https://schema.org/mentions"
@@ -156,7 +156,7 @@ type Review implements SearchableInterface & ThingInterface & ProvenanceEntityIn
   "https://schema.org/publisher"
   schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
   "https://schema.org/publishingPrinciples"
-  publishingPrinciples: URL
+  publishingPrinciples: String
   "https://schema.org/recordedAt"
   recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
   "https://schema.org/sourceOrganization"
@@ -164,7 +164,7 @@ type Review implements SearchableInterface & ThingInterface & ProvenanceEntityIn
   "https://schema.org/text"
   text: String
   "https://schema.org/thumbnailUrl"
-  thumbnailUrl: URL
+  thumbnailUrl: String
   "https://schema.org/translator"
   translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
   "https://schema.org/version"

--- a/src/schema/type/SoftwareApplication.graphql
+++ b/src/schema/type/SoftwareApplication.graphql
@@ -51,7 +51,7 @@ type SoftwareApplication implements SearchableInterface & ThingInterface & Prove
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type SoftwareApplication implements SearchableInterface & ThingInterface & Prove
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -144,7 +144,7 @@ type SoftwareApplication implements SearchableInterface & ThingInterface & Prove
   "https://schema.org/keywords"
   keywords: String
   "https://schema.org/license"
-  license: URL
+  license: String
   "https://schema.org/mainEntity"
   mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "OUT")
   "https://schema.org/mentions"
@@ -156,7 +156,7 @@ type SoftwareApplication implements SearchableInterface & ThingInterface & Prove
   "https://schema.org/publisher"
   schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
   "https://schema.org/publishingPrinciples"
-  publishingPrinciples: URL
+  publishingPrinciples: String
   "https://schema.org/recordedAt"
   recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
   "https://schema.org/sourceOrganization"
@@ -164,7 +164,7 @@ type SoftwareApplication implements SearchableInterface & ThingInterface & Prove
   "https://schema.org/text"
   text: String
   "https://schema.org/thumbnailUrl"
-  thumbnailUrl: URL
+  thumbnailUrl: String
   "https://schema.org/translator"
   translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
   "https://schema.org/version"
@@ -189,13 +189,13 @@ type SoftwareApplication implements SearchableInterface & ThingInterface & Prove
 #  "https://schema.org/countriesNotSupported"
 #  countriesNotSupported: [String]
   "https://schema.org/downloadUrl"
-  downloadUrl: URL
+  downloadUrl: String
   "https://schema.org/featureList"
   featureList: [String]
   "https://schema.org/fileSize"
   fileSize: String
   "https://schema.org/installUrl"
-  installUrl: URL
+  installUrl: String
   "https://schema.org/memoryRequirements"
   memoryRequirements : String
   "https://schema.org/operatingSystem"
@@ -207,7 +207,7 @@ type SoftwareApplication implements SearchableInterface & ThingInterface & Prove
   "https://schema.org/releaseNotes"
   releaseNotes: String
   "https://schema.org/screenshot"
-  screenshot: [URL]
+  screenshot: [String]
   "https://schema.org/softwareAddOn"
   softwareAddOn: [SoftwareApplication] @relation(name: "SOFTWARE_ADD_ON", direction: "OUT")
   "https://schema.org/softwareHelp"

--- a/src/schema/type/VideoObject.graphql
+++ b/src/schema/type/VideoObject.graphql
@@ -51,7 +51,7 @@ type VideoObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/alternateName"
   alternateName: String
   "https://schema.org/image"
-  image: URL
+  image: String
   "https://schema.org/mainEntityOfPage"
   mainEntityOfPage: [CreativeWorkInterface] @relation(name: "MAIN_ENTITY_OF_PAGE", direction: "OUT")
   "https://schema.org/name"
@@ -59,11 +59,11 @@ type VideoObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/potentialAction"
   potentialAction: [ActionInterface] @relation(name: "POTENTIAL_ACTION", direction: "OUT")
   "https://schema.org/sameAs"
-  sameAs: URL
+  sameAs: String
   "https://schema.org/subjectOf"
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: "OUT")
   "https://schema.org/url"
-  url: URL
+  url: String
 
   #######################
   ### SKOS properties ###
@@ -144,7 +144,7 @@ type VideoObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/keywords"
   keywords: String
   "https://schema.org/license"
-  license: URL
+  license: String
   "https://schema.org/mainEntity"
   mainEntity: ThingInterface @relation(name: "MAIN_ENTITY", direction: "OUT")
   "https://schema.org/mentions"
@@ -156,7 +156,7 @@ type VideoObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/publisher"
   schema_publisher: [Organization] @relation(name: "PUBLISHER", direction: "IN")
   "https://schema.org/publishingPrinciples"
-  publishingPrinciples: URL
+  publishingPrinciples: String
   "https://schema.org/recordedAt"
   recordedAt: Event @relation(name: "RECORDED_AT", direction: "OUT")
   "https://schema.org/sourceOrganization"
@@ -164,7 +164,7 @@ type VideoObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/text"
   text: String
   "https://schema.org/thumbnailUrl"
-  thumbnailUrl: URL
+  thumbnailUrl: String
   "https://schema.org/translator"
   translator: [LegalPersonInterface] @relation(name: "TRANSLATOR", direction: "IN")
   "https://schema.org/version"
@@ -185,11 +185,11 @@ type VideoObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "https://schema.org/contentSize"
   contentSize: String
   "https://schema.org/contentUrl"
-  contentUrl: URL
+  contentUrl: String
   "https://schema.org/duration"
   duration: Duration
   "https://schema.org/embedUrl"
-  embedUrl: URL
+  embedUrl: String
   "https://schema.org/encodesCreativeWork"
   encodesCreativeWork: [CreativeWorkInterface] @relation(name: "ENCODES_CREATIVE_WORK", direction: "OUT")
   "https://schema.org/height"


### PR DESCRIPTION
Fixes #134 

This custom scalar was causing neo4j-graphql-js to not generate
filters for these fields.
While it's nice to have some more specific types, we are not using this
scalar to do any kind of validation, and it's causing us to not be able
to use filters for many of our fields