### PR TITLE
fix: multiple control actions generated

### DIFF
--- a/src/commands/RequestControlActionCommand.js
+++ b/src/commands/RequestControlActionCommand.js
@@ -114,6 +114,7 @@ class RequestControlActionCommand {
       `MATCH (\`entryPoint\`:\`EntryPoint\` {\`identifier\`:"${requestInput.entryPointIdentifier}"})${this.queryHelper.generateRelationClause('EntryPoint', 'potentialAction')}(\`potentialControlAction\`:\`ControlAction\` {\`identifier\`:"${requestInput.potentialActionIdentifier}"})`,
       propertySelections ? `, ${propertySelections}` : '',
       `WITH \`entryPoint\`, \`potentialControlAction\`${nodeAliasesClause}`,
+      `LIMIT 1`,
       `CREATE (\`entryPoint\`)${this.queryHelper.generateRelationClause('ControlAction', 'target', null, true)}(\`controlAction\`:\`ControlAction\`:\`ActionInterface\`:\`ProvenanceActivityInterface\`:\`ProvenanceEntityInterface\`:\`ThingInterface\` {${this._generateControlActionPropertyClause(template.potentialAction)}})${this.queryHelper.generateRelationClause('ControlAction', 'wasDerivedFrom')}(\`potentialControlAction\`)`,
       `WITH \`entryPoint\`, \`potentialControlAction\`, \`controlAction\`${nodeAliasesClause}`,
       this._generateCreatePropertyValuesClause(template, requestInput),


### PR DESCRIPTION
This is a workaround for a bigger issue in the CE-API. The `identifier` fields are not unique and it is currently possible to have multiple nodes with the same identifier. This will be addressed in an update in the next few days (#141).

Fixes #138