### PR TITLE
fix(MusicPlaylist): add trackItemList property

### DIFF
--- a/src/schema/type/MusicPlaylist.graphql
+++ b/src/schema/type/MusicPlaylist.graphql
@@ -213,4 +213,6 @@ type MusicPlaylist implements SearchableInterface & ThingInterface & ProvenanceE
   numTracks: Int #aggregate from track property
   "https://schema.org/track"
   track: MusicRecording @relation(name: "MUSIC_RECORDING", direction: "OUT")
+  "https://schema.org/track"
+  trackItemList: ItemList @relation(name: "ITEM_LIST", direction: "OUT")
 }

--- a/src/schema/type/MusicPlaylist.graphql
+++ b/src/schema/type/MusicPlaylist.graphql
@@ -214,5 +214,5 @@ type MusicPlaylist implements SearchableInterface & ThingInterface & ProvenanceE
   "https://schema.org/track"
   track: MusicRecording @relation(name: "MUSIC_RECORDING", direction: "OUT")
   "https://schema.org/track"
-  trackItemList: ItemList @relation(name: "ITEM_LIST", direction: "OUT")
+  trackItemList: ItemList @relation(name: "TRACK_ITEM_LIST", direction: "OUT")
 }


### PR DESCRIPTION
This PR adds a `trackItemList` property to the `MusicPlaylist` type.

Fixes #126