### PR TITLE
fix(search): search query improvements

### DIFF
--- a/src/queries/SearchQuery.js
+++ b/src/queries/SearchQuery.js
@@ -16,7 +16,7 @@ class SearchQuery {
    */
   get query () {
     return [
-      `CALL db.index.fulltext.queryNodes("metadataSearchFields", "${this._generateQueryClause()}")`,
+      `CALL db.index.fulltext.queryNodes('metadataSearchFields', '${this._generateQueryClause()}')`,
       `YIELD \`node\`, \`score\``,
       this._generateTypeClause(),
       `RETURN node { .*, FRAGMENT_TYPE: HEAD(labels(node)), _searchScore: \`score\` }`,
@@ -40,7 +40,7 @@ class SearchQuery {
     const subString = this.params.substring.replace(/[^A-Za-z0-9.\-\s]/g, '')
 
     // prepare search substring
-    return `${field}:'${subString}' OR ${field}:'${subString}~'`
+    return `${field}:(\\\\"${subString}~\\\\" OR \\\\"${subString}*\\\\")`
   }
 
   /**
@@ -56,7 +56,7 @@ class SearchQuery {
     const subString = this.params.substring.replace(/[^A-Za-z0-9.\-\s]/g, '')
 
     // prepare search substring
-    return `'${subString}' OR '${subString}~'`
+    return `\\\\"${subString}~\\\\" OR \\\\"${subString}*\\\\"`
   }
 
   /**


### PR DESCRIPTION
Improve results drastically when having a typo in the subString.

**Search  MusicCompositions**

```graphql
query {
	searchMetadataText(
		substring: "Ludwig von Beethoven"
		onTypes: [MusicComposition]
		onFields: [title]
	) {
		title
		_searchScore
	}
}
```

Current results:

```json
{
  "data": {
    "searchMetadataText": [
      {
        "title": "32 Variations in C minor",
        "_searchScore": 13.919713020324707
      },
      {
        "title": "Magnificat secundi toni",
        "_searchScore": 12.121328353881836
      },
      {
        "title": "Magnificat primi toni",
        "_searchScore": 12.121328353881836
      },
      {
        "title": "Wilhelmus von Nassaue",
        "_searchScore": 11.430655479431152
      },
      {
        "title": "Ännchen von Tharau",
        "_searchScore": 11.430655479431152
      }
    ]
  }
}
```

Results from this  PR:

```json
{
  "data": {
    "searchMetadataText": [
      {
        "title": "O salutaris hostia (Ludwig van Beethoven) - ChoralWiki",
        "_searchScore": 7.559647560119629
      },
      {
        "title": "Opferlied, Opus 121b (Ludwig van Beethoven) - ChoralWiki",
        "_searchScore": 7.559647560119629
      },
      {
        "title": "The Vesper hymn (Ludwig van Beethoven) - ChoralWiki",
        "_searchScore": 7.559647560119629
      },
      {
        "title": "Sonntagmorgen (Ludwig Erk) - ChoralWiki",
        "_searchScore": 6.108694553375244
      },
      {
        "title": "Sperate (Ludwig Rotter) - ChoralWiki",
        "_searchScore": 6.108694553375244
      }
    ]
  }
}
```