### PR TITLE
feat(schema): Add Rating "templates"

### DIFF
--- a/src/routes/helpers/jsonld/Rating.json
+++ b/src/routes/helpers/jsonld/Rating.json
@@ -93,6 +93,18 @@
     "url": [
       "https://schema.org/url"
     ],
+    "wasGeneratedBy": [
+      "http://www.w3.org/ns/prov#wasGeneratedBy"
+    ],
+    "wasDerivedFrom": [
+      "http://www.w3.org/ns/prov#wasDerivedFrom"
+    ],
+    "wasAttributedTo": [
+      "http://www.w3.org/ns/prov#wasAttributedTo"
+    ],
+    "used": [
+      "http://www.w3.org/ns/prov#used"
+    ],
     "author": [
       "https://schema.org/author"
     ],

--- a/src/schema/type/Rating.graphql
+++ b/src/schema/type/Rating.graphql
@@ -1,5 +1,5 @@
 "https://schema.org/Rating"
-type Rating implements ThingInterface {
+type Rating implements ThingInterface & ProvenanceEntityInterface {
     ### Metadata properties ###
     "http://purl.org/dc/terms/identifier,https://schema.org/identifier"
     identifier: ID @id
@@ -61,6 +61,17 @@ type Rating implements ThingInterface {
     "https://schema.org/url"
     url: String
 
+    ############################################
+    ### ProvenanceEntityInterface properties ###
+    "http://www.w3.org/ns/prov#wasGeneratedBy"
+    wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: OUT)
+    "http://www.w3.org/ns/prov#wasDerivedFrom"
+    wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
+    "http://www.w3.org/ns/prov#wasAttributedTo"
+    wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+    "http://www.w3.org/ns/prov#used"
+    used: [ThingInterface] @relation(name: "USED", direction: OUT)
+
     #########################
     ### Rating properties ###
     "https://schema.org/author"
@@ -70,7 +81,7 @@ type Rating implements ThingInterface {
     "https://pending.schema.org/ratingExplanation"
     ratingExplanation: String
     "https://schema.org/ratingValue"
-    ratingValue: Int!
+    ratingValue: Int
     "https://schema.org/reviewAspect"
     reviewAspect: String
     "https://schema.org/worstRating"


### PR DESCRIPTION
When we add annotations which are a rating (e.g. scale from 1-10), we need a template so that the annotation tool can render a description and widget to allow a user to create an actual rating.

We do this by creating a Rating template object with name, bestValue, worstValue set to the relevant values, and additionalType set to "https://vocab.trompamusic.eu/vocab#RatingDefinition". This means that ratingValue has to be optional, as it shouldn't be set in the template.

When we create an actual rating by a user, relate it using `prov:wasDerivedFrom` to the template rating