### PR TITLE
feat(schema): Use Neo4j DateTime type for created and modfied fields

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -5,6 +5,7 @@ import walkSync from 'walk-sync'
 import { resolvers } from './resolvers'
 import { authenticationFieldTransformer } from './transformers/authenticationFieldTransformer'
 import { subscriptionFieldTransformer } from './transformers/subscriptionFieldTransformer'
+import { createdUpdatedFieldTransformer } from './transformers/createdUpdatedFieldTransformer'
 
 /*
  * Determine type definitions from which to auto generate queries and mutations
@@ -46,6 +47,7 @@ export const schema = transformSchema(
   }),
   [
     subscriptionFieldTransformer,
-    authenticationFieldTransformer
+    authenticationFieldTransformer,
+    createdUpdatedFieldTransformer,
   ]
 )

--- a/src/schema/interface/ActionInterface.graphql
+++ b/src/schema/interface/ActionInterface.graphql
@@ -34,9 +34,9 @@ interface ActionInterface {
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ########################
   ### ThingInterface properties ###

--- a/src/schema/interface/CreativeWorkInterface.graphql
+++ b/src/schema/interface/CreativeWorkInterface.graphql
@@ -34,9 +34,9 @@ interface CreativeWorkInterface {
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ########################
   ### ThingInterface properties ###

--- a/src/schema/interface/LegalPersonInterface.graphql
+++ b/src/schema/interface/LegalPersonInterface.graphql
@@ -33,9 +33,9 @@ interface LegalPersonInterface {
     "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
     type: String
     "http://purl.org/dc/terms/created"
-    created: String
+    created: _Neo4jDateTime
     "http://purl.org/dc/terms/modified"
-    modified: String
+    modified: _Neo4jDateTime
 
     #################################
     ### ThingInterface properties ###

--- a/src/schema/interface/MediaObjectInterface.graphql
+++ b/src/schema/interface/MediaObjectInterface.graphql
@@ -34,9 +34,9 @@ interface MediaObjectInterface {
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   #################################
   ### ThingInterface properties ###

--- a/src/schema/interface/OrganizationInterface.graphql
+++ b/src/schema/interface/OrganizationInterface.graphql
@@ -34,9 +34,9 @@ interface OrganizationInterface {
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ########################
   ### ThingInterface properties ###

--- a/src/schema/interface/PerformerInterface.graphql
+++ b/src/schema/interface/PerformerInterface.graphql
@@ -33,9 +33,9 @@ interface PerformerInterface {
     "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
     type: String
     "http://purl.org/dc/terms/created"
-    created: String
+    created: _Neo4jDateTime
     "http://purl.org/dc/terms/modified"
-    modified: String
+    modified: _Neo4jDateTime
 
     #################################
     ### ThingInterface properties ###

--- a/src/schema/interface/SearchableInterface.graphql
+++ b/src/schema/interface/SearchableInterface.graphql
@@ -57,9 +57,9 @@ interface SearchableInterface {
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/interface/ThingInterface.graphql
+++ b/src/schema/interface/ThingInterface.graphql
@@ -58,7 +58,7 @@ interface ThingInterface {
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 }

--- a/src/schema/type/Action.graphql
+++ b/src/schema/type/Action.graphql
@@ -34,9 +34,9 @@ type Action implements ThingInterface & ActionInterface & ProvenanceEntityInterf
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/AddAction.graphql
+++ b/src/schema/type/AddAction.graphql
@@ -34,9 +34,9 @@ type AddAction implements ThingInterface & ActionInterface & ProvenanceEntityInt
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ########################
   ### ThingInterface properties ###

--- a/src/schema/type/Article.graphql
+++ b/src/schema/type/Article.graphql
@@ -34,9 +34,9 @@ type Article implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/Audience.graphql
+++ b/src/schema/type/Audience.graphql
@@ -34,9 +34,9 @@ type Audience implements ThingInterface {
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
   ########################
   ### ThingInterface properties ###
   "https://schema.org/additionalType"

--- a/src/schema/type/AudioObject.graphql
+++ b/src/schema/type/AudioObject.graphql
@@ -34,9 +34,9 @@ type AudioObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/ControlAction.graphql
+++ b/src/schema/type/ControlAction.graphql
@@ -34,9 +34,9 @@ type ControlAction implements ThingInterface & ActionInterface & ProvenanceEntit
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ########################
   ### ThingInterface properties ###

--- a/src/schema/type/DataDownload.graphql
+++ b/src/schema/type/DataDownload.graphql
@@ -34,9 +34,9 @@ type DataDownload implements SearchableInterface & ThingInterface & ProvenanceEn
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/Dataset.graphql
+++ b/src/schema/type/Dataset.graphql
@@ -34,9 +34,9 @@ type Dataset implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/DefinedTerm.graphql
+++ b/src/schema/type/DefinedTerm.graphql
@@ -34,9 +34,9 @@ type DefinedTerm implements ThingInterface {
     "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
     type: String
     "http://purl.org/dc/terms/created"
-    created: String
+    created: _Neo4jDateTime
     "http://purl.org/dc/terms/modified"
-    modified: String
+    modified: _Neo4jDateTime
 
     #################################
     ### ThingInterface properties ###

--- a/src/schema/type/DefinedTermSet.graphql
+++ b/src/schema/type/DefinedTermSet.graphql
@@ -34,9 +34,9 @@ type DefinedTermSet implements CreativeWorkInterface & ThingInterface {
     "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
     type: String
     "http://purl.org/dc/terms/created"
-    created: String
+    created: _Neo4jDateTime
     "http://purl.org/dc/terms/modified"
-    modified: String
+    modified: _Neo4jDateTime
 
     #################################
     ### ThingInterface properties ###

--- a/src/schema/type/DeleteAction.graphql
+++ b/src/schema/type/DeleteAction.graphql
@@ -58,9 +58,9 @@ type DeleteAction implements ThingInterface & ActionInterface & ProvenanceEntity
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   #######################
   ### SKOS properties ###

--- a/src/schema/type/DigitalDocument.graphql
+++ b/src/schema/type/DigitalDocument.graphql
@@ -34,9 +34,9 @@ type DigitalDocument implements SearchableInterface & ThingInterface & Provenanc
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/DigitalDocumentPermission.graphql
+++ b/src/schema/type/DigitalDocumentPermission.graphql
@@ -34,9 +34,9 @@ type DigitalDocumentPermission implements ThingInterface & ProvenanceEntityInter
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   #################################
   ### ThingInterface properties ###

--- a/src/schema/type/EntryPoint.graphql
+++ b/src/schema/type/EntryPoint.graphql
@@ -34,9 +34,9 @@ type EntryPoint implements ThingInterface & ProvenanceEntityInterface {
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/Event.graphql
+++ b/src/schema/type/Event.graphql
@@ -34,9 +34,9 @@ type Event implements SearchableInterface & ThingInterface & ProvenanceEntityInt
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/ImageObject.graphql
+++ b/src/schema/type/ImageObject.graphql
@@ -34,9 +34,9 @@ type ImageObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/Intangible.graphql
+++ b/src/schema/type/Intangible.graphql
@@ -34,9 +34,9 @@ type Intangible implements SearchableInterface & ThingInterface & ProvenanceEnti
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
   ####################################
   ### SearchableInterface property ###
   _searchScore: Float

--- a/src/schema/type/ItemList.graphql
+++ b/src/schema/type/ItemList.graphql
@@ -34,9 +34,9 @@ type ItemList implements ThingInterface {
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   #################################
   ### ThingInterface properties ###

--- a/src/schema/type/ListItem.graphql
+++ b/src/schema/type/ListItem.graphql
@@ -34,9 +34,9 @@ type ListItem implements ThingInterface {
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   #################################
   ### ThingInterface properties ###

--- a/src/schema/type/MediaObject.graphql
+++ b/src/schema/type/MediaObject.graphql
@@ -34,9 +34,9 @@ type MediaObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/MusicAlbum.graphql
+++ b/src/schema/type/MusicAlbum.graphql
@@ -34,9 +34,9 @@ type MusicAlbum implements SearchableInterface & ThingInterface & ProvenanceEnti
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/MusicComposition.graphql
+++ b/src/schema/type/MusicComposition.graphql
@@ -34,9 +34,9 @@ type MusicComposition implements SearchableInterface & ThingInterface & Provenan
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/MusicGroup.graphql
+++ b/src/schema/type/MusicGroup.graphql
@@ -34,9 +34,9 @@ type MusicGroup implements SearchableInterface & ThingInterface & ProvenanceEnti
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/MusicPlaylist.graphql
+++ b/src/schema/type/MusicPlaylist.graphql
@@ -34,9 +34,9 @@ type MusicPlaylist implements SearchableInterface & ThingInterface & ProvenanceE
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/MusicRecording.graphql
+++ b/src/schema/type/MusicRecording.graphql
@@ -34,9 +34,9 @@ type MusicRecording implements SearchableInterface & ThingInterface & Provenance
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/Occupation.graphql
+++ b/src/schema/type/Occupation.graphql
@@ -34,9 +34,9 @@ type Occupation implements ThingInterface {
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ########################
   ### ThingInterface properties ###

--- a/src/schema/type/Organization.graphql
+++ b/src/schema/type/Organization.graphql
@@ -34,9 +34,9 @@ type Organization implements SearchableInterface & ThingInterface & ProvenanceEn
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/Person.graphql
+++ b/src/schema/type/Person.graphql
@@ -34,9 +34,9 @@ type Person implements SearchableInterface & ThingInterface & ProvenanceEntityIn
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/Place.graphql
+++ b/src/schema/type/Place.graphql
@@ -34,9 +34,9 @@ type Place implements SearchableInterface & ThingInterface & ProvenanceEntityInt
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/Product.graphql
+++ b/src/schema/type/Product.graphql
@@ -34,9 +34,9 @@ type Product implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/Property.graphql
+++ b/src/schema/type/Property.graphql
@@ -34,9 +34,9 @@ type Property implements ThingInterface {
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   #################################
   ### ThingInterface properties ###

--- a/src/schema/type/PropertyValue.graphql
+++ b/src/schema/type/PropertyValue.graphql
@@ -34,9 +34,9 @@ type PropertyValue implements ThingInterface {
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ########################
   ### ThingInterface properties ###

--- a/src/schema/type/PropertyValueSpecification.graphql
+++ b/src/schema/type/PropertyValueSpecification.graphql
@@ -34,9 +34,9 @@ type PropertyValueSpecification implements ThingInterface {
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   #################################
   ### ThingInterface properties ###

--- a/src/schema/type/Rating.graphql
+++ b/src/schema/type/Rating.graphql
@@ -34,9 +34,9 @@ type Rating implements ThingInterface {
     "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
     type: String
     "http://purl.org/dc/terms/created"
-    created: String
+    created: _Neo4jDateTime
     "http://purl.org/dc/terms/modified"
-    modified: String
+    modified: _Neo4jDateTime
 
     #################################
     ### ThingInterface properties ###

--- a/src/schema/type/ReplaceAction.graphql
+++ b/src/schema/type/ReplaceAction.graphql
@@ -34,9 +34,9 @@ type ReplaceAction implements ThingInterface & ActionInterface & ProvenanceEntit
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ########################
   ### ThingInterface properties ###

--- a/src/schema/type/Review.graphql
+++ b/src/schema/type/Review.graphql
@@ -34,9 +34,9 @@ type Review implements SearchableInterface & ThingInterface & ProvenanceEntityIn
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/SoftwareApplication.graphql
+++ b/src/schema/type/SoftwareApplication.graphql
@@ -34,9 +34,9 @@ type SoftwareApplication implements SearchableInterface & ThingInterface & Prove
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/schema/type/VideoObject.graphql
+++ b/src/schema/type/VideoObject.graphql
@@ -34,9 +34,9 @@ type VideoObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "http://purl.org/dc/terms/type,http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   type: String
   "http://purl.org/dc/terms/created"
-  created: String
+  created: _Neo4jDateTime
   "http://purl.org/dc/terms/modified"
-  modified: String
+  modified: _Neo4jDateTime
 
   ####################################
   ### SearchableInterface property ###

--- a/src/transformers/createdUpdatedFieldTransformer.js
+++ b/src/transformers/createdUpdatedFieldTransformer.js
@@ -51,7 +51,7 @@ export const createdUpdatedFieldTransformer = new TransformRootFields((operation
         fieldNode.arguments.push(buildArgument({ name: buildName({ name: 'created' }), value }))
       }
 
-      if (action === 'Create' || action === 'Update' || action === 'Update') {
+      if (action === 'Create' || action === 'Update' || action === 'Merge') {
         fieldNode.arguments.push(buildArgument({ name: buildName({ name: 'modified' }), value }))
       }
 

--- a/src/transformers/createdUpdatedFieldTransformer.js
+++ b/src/transformers/createdUpdatedFieldTransformer.js
@@ -1,0 +1,63 @@
+import { TransformRootFields } from 'graphql-tools'
+import { buildPropertyValue, parseFieldName } from '../utils/schema'
+import { buildArgument, buildName } from 'neo4j-graphql-js/dist/augment/ast'
+import { Kind } from 'graphql/language/kinds'
+
+export const createdUpdatedFieldTransformer = new TransformRootFields((operation, fieldName, field) => {
+  // Only needed for mutations
+  if (operation !== 'Mutation') {
+    return undefined
+  }
+
+  const { action } = parseFieldName(fieldName)
+
+  if (action !== 'Create' && action !== 'Update' && action !== 'Merge') {
+    return undefined
+  }
+
+  const next = field.resolve
+
+  field.resolve = (object, params, context, info) => {
+    info.fieldNodes = info.fieldNodes.map(fieldNode => {
+      const createdIndex = fieldNode.arguments.findIndex(argument => argument.name.value === 'created')
+      const modifiedIndex = fieldNode.arguments.findIndex(argument => argument.name.value === 'modified')
+
+      // remove given created and modified arguments
+      if (createdIndex !== -1) {
+        fieldNode.arguments.splice(createdIndex, 1)
+      }
+
+      if (modifiedIndex !== -1) {
+        fieldNode.arguments.splice(modifiedIndex, 1)
+      }
+
+      const date = new Date()
+
+      const value = {
+        kind: Kind.OBJECT,
+        fields: [
+          buildPropertyValue('year', Kind.INT, date.getUTCFullYear()),
+          buildPropertyValue('month', Kind.INT, date.getUTCMonth()),
+          buildPropertyValue('day', Kind.INT, date.getUTCDate()),
+          buildPropertyValue('hour', Kind.INT, date.getUTCHours()),
+          buildPropertyValue('minute', Kind.INT, date.getUTCMinutes()),
+          buildPropertyValue('second', Kind.INT, date.getUTCSeconds()),
+          buildPropertyValue('millisecond', Kind.INT, date.getUTCMilliseconds()),
+          buildPropertyValue('timezone', Kind.STRING, 'z')
+        ]
+      }
+
+      if (action === 'Create') {
+        fieldNode.arguments.push(buildArgument({ name: buildName({ name: 'created' }), value }))
+      }
+
+      if (action === 'Create' || action === 'Update' || action === 'Update') {
+        fieldNode.arguments.push(buildArgument({ name: buildName({ name: 'modified' }), value }))
+      }
+
+      return fieldNode
+    })
+
+    return next(object, params, context, info)
+  }
+})

--- a/src/utils/schema.js
+++ b/src/utils/schema.js
@@ -1,3 +1,6 @@
+import { Kind } from 'graphql/language/kinds'
+import { buildName } from 'neo4j-graphql-js/dist/augment/ast'
+
 /**
  * Parse the given field name into an action and type
  * @param {string} fieldName
@@ -23,3 +26,20 @@ export const generateScope = (mutation, fieldName) => {
 
   return `${mutation}:${type}:${action}`
 }
+
+/**
+ * Build an ObjectField AST node
+ * @param name
+ * @param kind
+ * @param value
+ * @return {{kind: "ObjectField", name: *, value: {kind, block: boolean, value}}}
+ */
+export const buildPropertyValue = (name, kind, value) => ({
+  kind: Kind.OBJECT_FIELD,
+  name: buildName({ name: name }),
+  value: {
+    kind: kind,
+    value: value,
+    block: false
+  }
+})


### PR DESCRIPTION
This was originally set to String, but it's nice to have it as a datatype that allows us to do more detailed filtering.

This isn't affected by https://github.com/trompamusic/ce-api/issues/91 because we will always have a full datetime for created and modified.

An addition to this is to integrate #112 at a later stage.

One issue that I saw, I can perform this mutation (adding created.formatted):
```
mutation {
  CreateRating(
creator: "https://testuser.trompa-solid.upf.edu/profile/card#me"
        ratingValue: 8
        bestRating: 10
        worstRating: 1
        created: {formatted: "2021-03-10T15:24:38.369017+00:00"}
) {
identifier
}
}
```

but this one fails:
```
mutation {
  UpdateRating (
    identifier: "05d9272c-3d00-48dc-ab25-bdab147291ea"
    created: {formatted:"2021-03-10T15:24:38.369017+00:00"}
  ) {
    identifier
  }
}
```
with this message:
```
{
  "errors": [
    {
      "message": "No such field: formatted",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "UpdateRating"
      ],
      "extensions": {
        "code": "INTERNAL_SERVER_ERROR",
        "exception": {
          "errors": [
            {
              "message": "No such field: formatted",
              "locations": [],
              "path": [
                "UpdateRating"
              ]
            }
          ],
          "stacktrace": [
            "Error: No such field: formatted",
            "    at new CombinedError (/app/node_modules/graphql-tools/src/stitching/errors.ts:90:5)",
            "    at Object.checkResultAndHandleErrors (/app/node_modules/graphql-tools/src/stitching/errors.ts:111:11)",
            "    at CheckResultAndHandleErrors.transformResult (/app/node_modules/graphql-tools/src/transforms/CheckResultAndHandleErrors.ts:15:12)",
            "    at /app/node_modules/graphql-tools/src/transforms/transforms.ts:37:45",
            "    at Array.reduce (<anonymous>)",
            "    at applyResultTransforms (/app/node_modules/graphql-tools/src/transforms/transforms.ts:35:21)",
            "    at /app/node_modules/graphql-tools/src/stitching/delegateToSchema.ts:104:12",
            "    at step (/app/node_modules/graphql-tools/dist/stitching/delegateToSchema.js:32:23)",
            "    at Object.next (/app/node_modules/graphql-tools/dist/stitching/delegateToSchema.js:13:53)",
            "    at fulfilled (/app/node_modules/graphql-tools/dist/stitching/delegateToSchema.js:4:58)"
          ]
        }
      }
    }
  ],
  "data": {
    "UpdateRating": null
  }
}
```

@ChristiaanScheermeijer  thinks it's related to https://github.com/neo4j-graphql/neo4j-graphql-js/issues/547