### PR TITLE
Fix/error created updated missing fields

### DIFF
--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,0 +1,37 @@
+version: '3'
+
+services:
+
+  neo4j:
+    build: ./neo4j
+    volumes:
+      - ./neo4j/data:/var/lib/neo4j/data
+    ports:
+      - 7474:7474
+      - 7687:7687
+    environment:
+      - NEO4J_dbms_security_procedures_unrestricted=apoc.*
+      - NEO4J_apoc_import_file_enabled=true
+      - NEO4J_apoc_export_file_enabled=true
+
+  api:
+    build: ./
+    command: ["npx", "nodemon",  "--inspect=0.0.0.0:9229", "--exec", "babel-node", "--watch", "src", "src/index.js", "start"]
+    ports:
+      - 4000:4000
+      - 9229:9229
+    environment:
+      NEO4J_URI: "bolt://neo4j:7687"
+      HOST: "0.0.0.0"
+      PORT: 4000
+      NEO4J_USER: "neo4j"
+      NEO4J_PASSWORD: "letmein"
+      JWT_SECRET: ""
+      JWT_AUTH_KEYS: "[{\"id\":\"local\",\"apiKey\":\"PZsG+oEW3K3QOoB5z0f30InzjXdBqM9LMtJa7BTg1xo=\",\"scopes\":[\"*\"]}]"
+      JWT_ISSUER: "https://api.trompamusic.eu"
+      JWT_EXPIRES: "1d"
+      DEBUG: ce-api-*
+    volumes:
+      - ./src:/app/src
+    links:
+      - neo4j

--- a/src/transformers/createdUpdatedFieldTransformer.js
+++ b/src/transformers/createdUpdatedFieldTransformer.js
@@ -18,6 +18,15 @@ export const createdUpdatedFieldTransformer = new TransformRootFields((operation
   const next = field.resolve
 
   field.resolve = (object, params, context, info) => {
+    const returnTypeFields = info.returnType.getFields()
+    const hasModifiedField = !!returnTypeFields['modified']
+    const hasCreatedField = !!returnTypeFields['created']
+
+    // returnType is missing either the created or modified fields
+    if (!hasModifiedField || !hasCreatedField) {
+      return next(object, params, context, info)
+    }
+
     info.fieldNodes = info.fieldNodes.map(fieldNode => {
       const createdIndex = fieldNode.arguments.findIndex(argument => argument.name.value === 'created')
       const modifiedIndex = fieldNode.arguments.findIndex(argument => argument.name.value === 'modified')


### PR DESCRIPTION
This PR fixes a crash when creating or updating a node that doesn't have the `created` or `modified` fields.

I've also added a `docker-compose.debug.yml` file which I'm using while debugging locally. This opens a Node debugger port on the host machine on port 9229.

You can use it by running:

```
$ docker-compose -f docker-compose.debug.yml up
```

After starting up, you should see the debuggable environment in Google Chrome here: about://inspect

For more information: https://nodejs.org/en/docs/guides/debugging-getting-started/