### PR TITLE
fix(search): register all searchable types with fulltext search dynamically

### DIFF
--- a/src/schema/enum.graphql
+++ b/src/schema/enum.graphql
@@ -11,6 +11,7 @@ enum SearchableInterfaceType {
   Action
   Article
   AudioObject
+  CreativeWork
   DataDownload
   Dataset
   DigitalDocument


### PR DESCRIPTION
Not all fields were being registered in the full-text migration file. I've updated this so it automatically adds the types and fields based on the schema definition.