### PR TITLE
feat(schema): make memberOf and member inverses

### DIFF
--- a/src/schema/interface/OrganizationInterface.graphql
+++ b/src/schema/interface/OrganizationInterface.graphql
@@ -146,7 +146,7 @@ interface OrganizationInterface {
   "https://schema.org/member"
   member: [LegalPersonInterface] @relation(name: "MEMBER", direction: IN)
   "https://schema.org/memberOf"
-  memberOf: [Organization] @relation(name: "MEMBER_OF", direction: OUT)
+  memberOf: [Organization] @relation(name: "MEMBER", direction: OUT)
   #naics
   "https://schema.org/numberOfEmployees"
   numberOfEmployees: Int

--- a/src/schema/type/MusicGroup.graphql
+++ b/src/schema/type/MusicGroup.graphql
@@ -152,7 +152,7 @@ type MusicGroup implements SearchableInterface & ThingInterface & ProvenanceEnti
   "https://schema.org/member"
   member: [LegalPersonInterface] @relation(name: "MEMBER", direction: IN)
   "https://schema.org/memberOf"
-  memberOf: [Organization] @relation(name: "MEMBER_OF", direction: OUT)
+  memberOf: [Organization] @relation(name: "MEMBER", direction: OUT)
   #naics
   "https://schema.org/numberOfEmployees"
   numberOfEmployees: Int

--- a/src/schema/type/Organization.graphql
+++ b/src/schema/type/Organization.graphql
@@ -152,7 +152,7 @@ type Organization implements SearchableInterface & ThingInterface & ProvenanceEn
   "https://schema.org/member"
   member: [LegalPersonInterface] @relation(name: "MEMBER", direction: IN)
   "https://schema.org/memberOf"
-  memberOf: [Organization] @relation(name: "MEMBER_OF", direction: OUT)
+  memberOf: [Organization] @relation(name: "MEMBER", direction: OUT)
   #naics
   "https://schema.org/numberOfEmployees"
   numberOfEmployees: Int

--- a/src/schema/type/Person.graphql
+++ b/src/schema/type/Person.graphql
@@ -159,7 +159,7 @@ type Person implements SearchableInterface & ThingInterface & ProvenanceEntityIn
   knowsLanguage: String
   #makesOffer
   "https://schema.org/memberOf"
-  memberOf: [Organization] @relation(name: "MEMBER_OF", direction: OUT)
+  memberOf: [Organization] @relation(name: "MEMBER", direction: OUT)
 #  "https://schema.org/naics"
 #  naics
   "https://schema.org/nationality"


### PR DESCRIPTION
according to https://schema.org/member the inverse is memberOf, so these relations should use the same relation name in the graphql definition.

This PR does not have to be released urgently.