### PR TITLE
feat(schema): add skos:broader to DefinedTerm

### DIFF
--- a/src/routes/helpers/jsonld/DefinedTerm.json
+++ b/src/routes/helpers/jsonld/DefinedTerm.json
@@ -98,6 +98,9 @@
     ],
     "inDefinedTermSet": [
       "https://pending.schema.org/inDefinedTermSet"
+    ],
+    "broader": [
+      "http://www.w3.org/2004/02/skos/core#broader"
     ]
   }
 }

--- a/src/schema/type/DefinedTerm.graphql
+++ b/src/schema/type/DefinedTerm.graphql
@@ -69,4 +69,12 @@ type DefinedTerm implements ThingInterface {
     # TODO: This should only be a relation to one DefinedTermSet
     "https://pending.schema.org/inDefinedTermSet"
     inDefinedTermSet: [DefinedTermSet] @relation(name: "HAS_DEFINED_TERM", direction: IN)
+
+    #######################
+    ### SKOS properties ###
+    # When we use a DefinedTerm to refer to an annotation motivation, we have to add the movitavtion
+    # of which this term is a more specific version of to skos:broader. If you do this, you should
+    # also add http://www.w3.org/ns/oa#Motivation as an additionalType
+    "http://www.w3.org/2004/02/skos/core#broader"
+    broader: String
 }


### PR DESCRIPTION
We use DefinedTermSets to create "Annotation palettes", collections of annotation motivations that are used for a particular annotation task.
The DefinedTerms inside each DefinedTermSet are a special case of an existing web audio motivation (oa:Motivation), and need to be related to that motivation with the property `skos:broader`