### PR TITLE
Feat/add property value derived from relation

### DIFF
--- a/src/routes/helpers/jsonld/PropertyValue.json
+++ b/src/routes/helpers/jsonld/PropertyValue.json
@@ -93,6 +93,18 @@
     "url": [
       "https://schema.org/url"
     ],
+    "wasGeneratedBy": [
+      "http://www.w3.org/ns/prov#wasGeneratedBy"
+    ],
+    "wasDerivedFrom": [
+      "http://www.w3.org/ns/prov#wasDerivedFrom"
+    ],
+    "wasAttributedTo": [
+      "http://www.w3.org/ns/prov#wasAttributedTo"
+    ],
+    "used": [
+      "http://www.w3.org/ns/prov#used"
+    ],
     "propertyID": [
       "https://schema.org/propertyID"
     ],

--- a/src/schema/type/PropertyValue.graphql
+++ b/src/schema/type/PropertyValue.graphql
@@ -61,6 +61,17 @@ type PropertyValue implements ThingInterface {
   "https://schema.org/url"
   url: String
 
+  ######################################
+  ### ProvenanceEntityInterface properties ###
+  "http://www.w3.org/ns/prov#wasGeneratedBy"
+  wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: OUT)
+  "http://www.w3.org/ns/prov#wasDerivedFrom"
+  wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
+  "http://www.w3.org/ns/prov#wasAttributedTo"
+  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  "http://www.w3.org/ns/prov#used"
+  used: [ThingInterface] @relation(name: "USED", direction: OUT)
+
   ################################
   ### PropertyValue properties ###
   #maxValue: Int


### PR DESCRIPTION
This PR updates the RequestControlAction mutation to include relations from the generated **PropertyValue** nodes to their corresponding template **Property** or **PropertyValueSpecification** nodes.

It needed some refactoring since aliases were only generated for the request input. This prevented creation of the **PropertyValue** created based on the _defaultValue_.

![image](https://user-images.githubusercontent.com/3996119/111788712-ae0b3300-88c0-11eb-8320-ca04deb1825c.png)


```graphql
query {
  ControlAction(identifier:"6d4128ba-97d6-4f60-9ba7-96da8af48f09") {
    object {
      identifier
      name
      ... on PropertyValue {
      	wasDerivedFrom {
          identifier
          name
          ... on PropertyValueSpecification {
            defaultValue
          }
          ... on Property {
            rangeIncludes
          }
        }
      }
    }
  }
}
```

```json
{
  "data": {
    "ControlAction": [
      {
        "object": [
          {
            "identifier": "fca702d3-22b6-40bb-933d-e87172ff23d9",
            "name": "targetFile",
            "wasDerivedFrom": [
              {
                "identifier": "2c796031-a303-460a-849d-0be95fb96b03",
                "name": "targetFile",
                "rangeIncludes": [
                  "DigitalDocument"
                ]
              }
            ]
          },
          {
            "identifier": "4ccbd009-6674-42d0-9a4d-3f014e14ab24",
            "name": "resultName",
            "wasDerivedFrom": [
              {
                "identifier": "f145799e-9612-43cb-9164-ac2d9ea2f460",
                "name": "Result name",
                "defaultValue": ""
              }
            ]
          }
        ]
      }
    ]
  }
}
```

Fixes #128