### PR TITLE
feat(json-ld): Return error if document lang doesn't match accept-lang

### DIFF
--- a/src/routes/helpers/document.js
+++ b/src/routes/helpers/document.js
@@ -60,3 +60,26 @@ const getNodeProperties = (session, type, identifier, host) => {
       throw error
     })
 }
+
+export const isValidLanguage = (data, acceptLanguage) => {
+  /*
+  Checks if the Accept-Language header matches the language field of a document.
+  For a header like fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5
+  remove scores and reduce language codes down to 2 characters.
+  If Accept-Language contains *, or if it contains the value of data.language
+  then return true, otherwise return false;
+   */
+  if (!acceptLanguage) {
+    // If language header isn't set, it's valid
+    return true;
+  }
+  const langs = acceptLanguage.replaceAll(" ", "").split(",").map(
+      e => e.split(";")[0].slice(0,2)
+  );
+  if (langs.includes("*")) {
+    // * as an accepted language = all languages
+    return true;
+  }
+  // Otherwise only return true if the document language is an accepted language
+  return langs.includes(data.language);
+}

--- a/src/routes/helpers/transformers.js
+++ b/src/routes/helpers/transformers.js
@@ -29,6 +29,7 @@ const convertScalarToPerson = value => {
  * Transform document to a JSON-LD structured document
  * @param {string} type
  * @param {Object} data
+ * @param {string} required_language: the language that this data should be in
  * @returns {Object} JSON-LD structured document
  */
 export const transformJsonLD = (type, data) => {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,6 +1,6 @@
 import validator from 'validator'
 import { Router } from 'express'
-import { getDocument } from './helpers/document'
+import { getDocument, isValidLanguage } from './helpers/document'
 import { transformJsonLD } from './helpers/transformers'
 import { info } from '../utils/logger'
 import { generateToken } from '../auth/auth'
@@ -20,6 +20,7 @@ router.get('/health', (req, res) => {
 router.get('/:identifier', (req, res) => {
   const { identifier } = req.params
   const accept = req.headers.accept || 'application/json'
+  const acceptLang = req.headers["accept-language"]
 
   // Validate the identifier
   if (!validator.isUUID(identifier)) {
@@ -32,6 +33,9 @@ router.get('/:identifier', (req, res) => {
     .then(({ data, type }) => {
       // Transform document to JSON-LD
       if (accept === 'application/ld+json') {
+        if (!isValidLanguage(data, acceptLang)) {
+          return res.status(406).send()
+        }
         return res.status(200).send(transformJsonLD(type, data))
       }
 


### PR DESCRIPTION
As discussed to add to D2.3

if lang is set and accept-lang is set and they're equal, return the document
if they're both set and different, return an error
if lang is null and no accept-lang set, return the document
If lang is null and accept-lang is set, return an error (pending to determine if this should be an error or success)

waiting for @musicog to tell us what the http status code should be, it shouldn't be 400.