### PR TITLE
feat(schema): allow wasAttributedTo to be a SoftwareApplication

### DIFF
--- a/src/schema/interface/ActionInterface.graphql
+++ b/src/schema/interface/ActionInterface.graphql
@@ -81,7 +81,7 @@ interface ActionInterface {
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/interface/AgentInterface.graphql
+++ b/src/schema/interface/AgentInterface.graphql
@@ -1,8 +1,7 @@
-"https://schema.org/DigitalDocumentPermission"
-type DigitalDocumentPermission implements ThingInterface & ProvenanceEntityInterface {
+interface AgentInterface  {
   ### Metadata properties ###
   "http://purl.org/dc/terms/identifier,https://schema.org/identifier"
-  identifier: ID @id
+  identifier: ID
   "http://purl.org/dc/terms/contributor,https://schema.org/contributor"
   contributor: String
   "http://purl.org/dc/terms/coverage"
@@ -38,7 +37,7 @@ type DigitalDocumentPermission implements ThingInterface & ProvenanceEntityInter
   "http://purl.org/dc/terms/modified"
   modified: _Neo4jDateTime
 
-  #################################
+  ########################
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
@@ -60,34 +59,4 @@ type DigitalDocumentPermission implements ThingInterface & ProvenanceEntityInter
   subjectOf: [CreativeWorkInterface] @relation(name: "SUBJECT_OF", direction: OUT)
   "https://schema.org/url"
   url: String
-
-  #######################
-  ### SKOS properties ###
-  "http://www.w3.org/2004/02/skos/core#broadMatch"
-  broadMatch: [DigitalDocumentPermission]  @relation(name: "BROAD_MATCH", direction: OUT)
-  "http://www.w3.org/2004/02/skos/core#closeMatch"
-  closeMatch: [DigitalDocumentPermission]  @relation(name: "CLOSE_MATCH", direction: OUT)
-  "http://www.w3.org/2004/02/skos/core#exactMatch"
-  exactMatch: [DigitalDocumentPermission]  @relation(name: "EXACT_MATCH", direction: OUT)
-  "http://www.w3.org/2004/02/skos/core#narrowMatch"
-  narrowMatch: [DigitalDocumentPermission]  @relation(name: "NARROW_MATCH", direction: OUT)
-  "http://www.w3.org/2004/02/skos/core#relatedMatch"
-  relatedMatch: [ThingInterface]  @relation(name: "RELATED_MATCH", direction: OUT)
-
-  ######################################
-  ### ProvenanceEntityInterface properties ###
-  "http://www.w3.org/ns/prov#wasGeneratedBy"
-  wasGeneratedBy: [ActionInterface] @relation(name: "WAS_GENERATED_BY", direction: OUT)
-  "http://www.w3.org/ns/prov#wasDerivedFrom"
-  wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
-  "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
-  "http://www.w3.org/ns/prov#used"
-  used: [ThingInterface] @relation(name: "USED", direction: OUT)
-  ############################################
-  ### DigitalDocumentPermission properties ###
-  "https://schema.org/grantee"
-  grantee: [LegalPersonInterface] @relation(name: "GRANTEE", direction: IN)
-  "https://schema.org/permissionType"
-  permissionType: DigitalDocumentPermissionType
 }

--- a/src/schema/interface/CreativeWorkInterface.graphql
+++ b/src/schema/interface/CreativeWorkInterface.graphql
@@ -81,7 +81,7 @@ interface CreativeWorkInterface {
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/interface/LegalPersonInterface.graphql
+++ b/src/schema/interface/LegalPersonInterface.graphql
@@ -63,13 +63,13 @@ interface LegalPersonInterface {
     #######################
     ### SKOS properties ###
     "http://www.w3.org/2004/02/skos/core#broadMatch"
-    broadMatch: [LegalPersonInterface]  @relation(name: "BROAD_MATCH", direction: OUT)
+    broadMatch: [LegalPersonInterface] @relation(name: "BROAD_MATCH", direction: OUT)
     "http://www.w3.org/2004/02/skos/core#closeMatch"
-    closeMatch: [LegalPersonInterface]  @relation(name: "CLOSE_MATCH", direction: OUT)
+    closeMatch: [LegalPersonInterface] @relation(name: "CLOSE_MATCH", direction: OUT)
     "http://www.w3.org/2004/02/skos/core#exactMatch"
-    exactMatch: [LegalPersonInterface]  @relation(name: "EXACT_MATCH", direction: OUT)
+    exactMatch: [LegalPersonInterface] @relation(name: "EXACT_MATCH", direction: OUT)
     "http://www.w3.org/2004/02/skos/core#narrowMatch"
-    narrowMatch: [LegalPersonInterface]  @relation(name: "NARROW_MATCH", direction: OUT)
+    narrowMatch: [LegalPersonInterface] @relation(name: "NARROW_MATCH", direction: OUT)
     "http://www.w3.org/2004/02/skos/core#relatedMatch"
     relatedMatch: [ThingInterface] @relation(name: "RELATED_MATCH", direction: OUT)
 
@@ -80,7 +80,7 @@ interface LegalPersonInterface {
     "http://www.w3.org/ns/prov#wasDerivedFrom"
     wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
     "http://www.w3.org/ns/prov#wasAttributedTo"
-    wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+    wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
     "http://www.w3.org/ns/prov#used"
     used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/interface/MediaObjectInterface.graphql
+++ b/src/schema/interface/MediaObjectInterface.graphql
@@ -81,7 +81,7 @@ interface MediaObjectInterface {
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/interface/OrganizationInterface.graphql
+++ b/src/schema/interface/OrganizationInterface.graphql
@@ -64,13 +64,13 @@ interface OrganizationInterface {
   #######################
   ### SKOS properties ###
   "http://www.w3.org/2004/02/skos/core#broadMatch"
-  broadMatch: [LegalPersonInterface]  @relation(name: "BROAD_MATCH", direction: OUT)
+  broadMatch: [LegalPersonInterface] @relation(name: "BROAD_MATCH", direction: OUT)
   "http://www.w3.org/2004/02/skos/core#closeMatch"
-  closeMatch: [LegalPersonInterface]  @relation(name: "CLOSE_MATCH", direction: OUT)
+  closeMatch: [LegalPersonInterface] @relation(name: "CLOSE_MATCH", direction: OUT)
   "http://www.w3.org/2004/02/skos/core#exactMatch"
-  exactMatch: [LegalPersonInterface]  @relation(name: "EXACT_MATCH", direction: OUT)
+  exactMatch: [LegalPersonInterface] @relation(name: "EXACT_MATCH", direction: OUT)
   "http://www.w3.org/2004/02/skos/core#narrowMatch"
-  narrowMatch: [LegalPersonInterface]  @relation(name: "NARROW_MATCH", direction: OUT)
+  narrowMatch: [LegalPersonInterface] @relation(name: "NARROW_MATCH", direction: OUT)
   "http://www.w3.org/2004/02/skos/core#relatedMatch"
   relatedMatch: [ThingInterface]  @relation(name: "RELATED_MATCH", direction: OUT)
 
@@ -81,7 +81,7 @@ interface OrganizationInterface {
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
   ###########################################

--- a/src/schema/interface/PerformerInterface.graphql
+++ b/src/schema/interface/PerformerInterface.graphql
@@ -80,7 +80,7 @@ interface PerformerInterface {
     "http://www.w3.org/ns/prov#wasDerivedFrom"
     wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
     "http://www.w3.org/ns/prov#wasAttributedTo"
-    wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+    wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
     "http://www.w3.org/ns/prov#used"
     used: [ThingInterface] @relation(name: "USED", direction: OUT)
 }

--- a/src/schema/interface/ProvenanceEntityInterface.graphql
+++ b/src/schema/interface/ProvenanceEntityInterface.graphql
@@ -7,7 +7,7 @@ interface ProvenanceEntityInterface {
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 }

--- a/src/schema/type/Action.graphql
+++ b/src/schema/type/Action.graphql
@@ -85,7 +85,7 @@ type Action implements ThingInterface & ActionInterface & ProvenanceEntityInterf
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/AddAction.graphql
+++ b/src/schema/type/AddAction.graphql
@@ -68,7 +68,7 @@ type AddAction implements ThingInterface & ActionInterface & ProvenanceEntityInt
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/Article.graphql
+++ b/src/schema/type/Article.graphql
@@ -85,7 +85,7 @@ type Article implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/AudioObject.graphql
+++ b/src/schema/type/AudioObject.graphql
@@ -85,7 +85,7 @@ type AudioObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/ControlAction.graphql
+++ b/src/schema/type/ControlAction.graphql
@@ -82,7 +82,7 @@ type ControlAction implements ThingInterface & ActionInterface & ProvenanceEntit
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/DataDownload.graphql
+++ b/src/schema/type/DataDownload.graphql
@@ -85,7 +85,7 @@ type DataDownload implements SearchableInterface & ThingInterface & ProvenanceEn
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/Dataset.graphql
+++ b/src/schema/type/Dataset.graphql
@@ -85,7 +85,7 @@ type Dataset implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/DefinedTermSet.graphql
+++ b/src/schema/type/DefinedTermSet.graphql
@@ -81,7 +81,7 @@ type DefinedTermSet implements CreativeWorkInterface & ThingInterface {
     "http://www.w3.org/ns/prov#wasDerivedFrom"
     wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
     "http://www.w3.org/ns/prov#wasAttributedTo"
-    wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+    wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
     "http://www.w3.org/ns/prov#used"
     used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/DeleteAction.graphql
+++ b/src/schema/type/DeleteAction.graphql
@@ -82,7 +82,7 @@ type DeleteAction implements ThingInterface & ActionInterface & ProvenanceEntity
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/DigitalDocument.graphql
+++ b/src/schema/type/DigitalDocument.graphql
@@ -85,7 +85,7 @@ type DigitalDocument implements SearchableInterface & ThingInterface & Provenanc
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/EntryPoint.graphql
+++ b/src/schema/type/EntryPoint.graphql
@@ -72,7 +72,7 @@ type EntryPoint implements ThingInterface & ProvenanceEntityInterface {
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/Event.graphql
+++ b/src/schema/type/Event.graphql
@@ -85,7 +85,7 @@ type Event implements SearchableInterface & ThingInterface & ProvenanceEntityInt
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/ImageObject.graphql
+++ b/src/schema/type/ImageObject.graphql
@@ -85,7 +85,7 @@ type ImageObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/Intangible.graphql
+++ b/src/schema/type/Intangible.graphql
@@ -83,7 +83,7 @@ type Intangible implements SearchableInterface & ThingInterface & ProvenanceEnti
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 }

--- a/src/schema/type/MediaObject.graphql
+++ b/src/schema/type/MediaObject.graphql
@@ -85,7 +85,7 @@ type MediaObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/MusicAlbum.graphql
+++ b/src/schema/type/MusicAlbum.graphql
@@ -85,7 +85,7 @@ type MusicAlbum implements SearchableInterface & ThingInterface & ProvenanceEnti
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/MusicComposition.graphql
+++ b/src/schema/type/MusicComposition.graphql
@@ -85,7 +85,7 @@ type MusicComposition implements SearchableInterface & ThingInterface & Provenan
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/MusicGroup.graphql
+++ b/src/schema/type/MusicGroup.graphql
@@ -1,5 +1,5 @@
 "https://schema.org/MusicGroup,http://purl.org/ontology/mo/MusicGroup"
-type MusicGroup implements SearchableInterface & ThingInterface & ProvenanceEntityInterface & ProvenanceAgentInterface & OrganizationInterface & LegalPersonInterface & PerformerInterface {
+type MusicGroup implements SearchableInterface & ThingInterface & ProvenanceEntityInterface & ProvenanceAgentInterface & OrganizationInterface & LegalPersonInterface & AgentInterface & PerformerInterface {
   ### Metadata properties ###
   "http://purl.org/dc/terms/identifier,https://schema.org/identifier"
   identifier: ID @id
@@ -85,7 +85,7 @@ type MusicGroup implements SearchableInterface & ThingInterface & ProvenanceEnti
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/MusicPlaylist.graphql
+++ b/src/schema/type/MusicPlaylist.graphql
@@ -85,7 +85,7 @@ type MusicPlaylist implements SearchableInterface & ThingInterface & ProvenanceE
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/MusicRecording.graphql
+++ b/src/schema/type/MusicRecording.graphql
@@ -85,7 +85,7 @@ type MusicRecording implements SearchableInterface & ThingInterface & Provenance
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/Organization.graphql
+++ b/src/schema/type/Organization.graphql
@@ -1,5 +1,5 @@
 "https://schema.org/Organization,http://www.w3.org/ns/prov#Agent"
-type Organization implements SearchableInterface & ThingInterface & ProvenanceEntityInterface & ProvenanceAgentInterface & OrganizationInterface & LegalPersonInterface {
+type Organization implements SearchableInterface & ThingInterface & ProvenanceEntityInterface & ProvenanceAgentInterface & OrganizationInterface & LegalPersonInterface & AgentInterface {
   ### Metadata properties ###
   "http://purl.org/dc/terms/identifier,https://schema.org/identifier"
   identifier: ID @id
@@ -68,13 +68,13 @@ type Organization implements SearchableInterface & ThingInterface & ProvenanceEn
   #######################
   ### SKOS properties ###
   "http://www.w3.org/2004/02/skos/core#broadMatch"
-  broadMatch: [LegalPersonInterface]  @relation(name: "BROAD_MATCH", direction: OUT)
+  broadMatch: [LegalPersonInterface] @relation(name: "BROAD_MATCH", direction: OUT)
   "http://www.w3.org/2004/02/skos/core#closeMatch"
-  closeMatch: [LegalPersonInterface]  @relation(name: "CLOSE_MATCH", direction: OUT)
+  closeMatch: [LegalPersonInterface] @relation(name: "CLOSE_MATCH", direction: OUT)
   "http://www.w3.org/2004/02/skos/core#exactMatch"
-  exactMatch: [LegalPersonInterface]  @relation(name: "EXACT_MATCH", direction: OUT)
+  exactMatch: [LegalPersonInterface] @relation(name: "EXACT_MATCH", direction: OUT)
   "http://www.w3.org/2004/02/skos/core#narrowMatch"
-  narrowMatch: [LegalPersonInterface]  @relation(name: "NARROW_MATCH", direction: OUT)
+  narrowMatch: [LegalPersonInterface] @relation(name: "NARROW_MATCH", direction: OUT)
   "http://www.w3.org/2004/02/skos/core#relatedMatch"
   relatedMatch: [ThingInterface]  @relation(name: "RELATED_MATCH", direction: OUT)
 
@@ -85,7 +85,7 @@ type Organization implements SearchableInterface & ThingInterface & ProvenanceEn
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/Person.graphql
+++ b/src/schema/type/Person.graphql
@@ -1,5 +1,5 @@
 "https://schema.org/Person,http://purl.org/dc/terms/Agent,http://www.w3.org/ns/prov#Agent"
-type Person implements SearchableInterface & ThingInterface & ProvenanceEntityInterface & ProvenanceAgentInterface & LegalPersonInterface & PerformerInterface {
+type Person implements SearchableInterface & ThingInterface & ProvenanceEntityInterface & ProvenanceAgentInterface & LegalPersonInterface & AgentInterface & PerformerInterface {
   ### Metadata properties ###
   "http://purl.org/dc/terms/identifier,https://schema.org/identifier"
   identifier: ID @id
@@ -68,13 +68,13 @@ type Person implements SearchableInterface & ThingInterface & ProvenanceEntityIn
   #######################
   ### SKOS properties ###
   "http://www.w3.org/2004/02/skos/core#broadMatch"
-  broadMatch: [LegalPersonInterface]  @relation(name: "BROAD_MATCH", direction: OUT)
+  broadMatch: [LegalPersonInterface] @relation(name: "BROAD_MATCH", direction: OUT)
   "http://www.w3.org/2004/02/skos/core#closeMatch"
-  closeMatch: [LegalPersonInterface]  @relation(name: "CLOSE_MATCH", direction: OUT)
+  closeMatch: [LegalPersonInterface] @relation(name: "CLOSE_MATCH", direction: OUT)
   "http://www.w3.org/2004/02/skos/core#exactMatch"
-  exactMatch: [LegalPersonInterface]  @relation(name: "EXACT_MATCH", direction: OUT)
+  exactMatch: [LegalPersonInterface] @relation(name: "EXACT_MATCH", direction: OUT)
   "http://www.w3.org/2004/02/skos/core#narrowMatch"
-  narrowMatch: [LegalPersonInterface]  @relation(name: "NARROW_MATCH", direction: OUT)
+  narrowMatch: [LegalPersonInterface] @relation(name: "NARROW_MATCH", direction: OUT)
   "http://www.w3.org/2004/02/skos/core#relatedMatch"
   relatedMatch: [ThingInterface] @relation(name: "RELATED_MATCH", direction: OUT)
 
@@ -85,7 +85,7 @@ type Person implements SearchableInterface & ThingInterface & ProvenanceEntityIn
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/Place.graphql
+++ b/src/schema/type/Place.graphql
@@ -85,7 +85,7 @@ type Place implements SearchableInterface & ThingInterface & ProvenanceEntityInt
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/Product.graphql
+++ b/src/schema/type/Product.graphql
@@ -85,7 +85,7 @@ type Product implements SearchableInterface & ThingInterface & ProvenanceEntityI
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
   ##########################

--- a/src/schema/type/PropertyValue.graphql
+++ b/src/schema/type/PropertyValue.graphql
@@ -68,7 +68,7 @@ type PropertyValue implements ThingInterface {
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/Rating.graphql
+++ b/src/schema/type/Rating.graphql
@@ -68,7 +68,7 @@ type Rating implements ThingInterface & ProvenanceEntityInterface {
     "http://www.w3.org/ns/prov#wasDerivedFrom"
     wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
     "http://www.w3.org/ns/prov#wasAttributedTo"
-    wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+    wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
     "http://www.w3.org/ns/prov#used"
     used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/ReplaceAction.graphql
+++ b/src/schema/type/ReplaceAction.graphql
@@ -81,7 +81,7 @@ type ReplaceAction implements ThingInterface & ActionInterface & ProvenanceEntit
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/Review.graphql
+++ b/src/schema/type/Review.graphql
@@ -85,7 +85,7 @@ type Review implements SearchableInterface & ThingInterface & ProvenanceEntityIn
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/SoftwareApplication.graphql
+++ b/src/schema/type/SoftwareApplication.graphql
@@ -1,5 +1,5 @@
 "https://schema.org/SoftwareApplication"
-type SoftwareApplication implements SearchableInterface & ThingInterface & ProvenanceEntityInterface & CreativeWorkInterface {
+type SoftwareApplication implements SearchableInterface & ThingInterface & ProvenanceEntityInterface & CreativeWorkInterface & AgentInterface {
   ### Metadata properties ###
   "http://purl.org/dc/terms/identifier,https://schema.org/identifier"
   identifier: ID @id
@@ -85,7 +85,7 @@ type SoftwareApplication implements SearchableInterface & ThingInterface & Prove
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 

--- a/src/schema/type/VideoObject.graphql
+++ b/src/schema/type/VideoObject.graphql
@@ -85,7 +85,7 @@ type VideoObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   "http://www.w3.org/ns/prov#wasDerivedFrom"
   wasDerivedFrom: [ThingInterface] @relation(name: "WAS_DERIVED_FROM", direction: OUT)
   "http://www.w3.org/ns/prov#wasAttributedTo"
-  wasAttributedTo: [LegalPersonInterface]  @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
+  wasAttributedTo: [AgentInterface] @relation(name: "WAS_ATTRIBUTED_TO", direction: OUT)
   "http://www.w3.org/ns/prov#used"
   used: [ThingInterface] @relation(name: "USED", direction: OUT)
 


### PR DESCRIPTION
The prov schema says that the value of wasAttributedTo can be any
agent, but it can currently only be a LegalPersonInterface.
We want to use this property to indicate that a node was created
by a particular software application. To do this, introduce an
AgentInterface which is implemented by SoftwareApplication and the
types that already implemented LegalPersonInterface.

This allows us to make queries like "give me all of the MediaObjects created by piece of software x:
```
query {
  MediaObject(filter:{wasAttributedTo:{identifier:"7a9798bc-abfc-41ca-8861-9c1de850010a"}}) {
    identifier
    name
    wasAttributedTo {
      ... on SoftwareApplication {
        name
      }
    }
  }
}
```

```
{
  "data": {
    "MediaObject": [
      {
        "identifier": "31588500-41cc-40ba-91cd-5fa875c374ca",
        "name": "some mediaobjct",
        "wasAttributedTo": [
          {
            "name": "mysoftware"
          }
        ]
      },
      {
        "identifier": "ff703a20-41fe-4cfb-8e82-8b563f4e6154",
        "name": "some other mediaobjct",
        "wasAttributedTo": [
          {
            "name": "mysoftware"
          }
        ]
      }
    ]
  }
}
```