### PR TITLE
feat(schema): Use custom trompa type for additionalProperty field

### DIFF
--- a/src/routes/helpers/jsonld/Action.json
+++ b/src/routes/helpers/jsonld/Action.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/AddAction.json
+++ b/src/routes/helpers/jsonld/AddAction.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/Article.json
+++ b/src/routes/helpers/jsonld/Article.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/Audience.json
+++ b/src/routes/helpers/jsonld/Audience.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/AudioObject.json
+++ b/src/routes/helpers/jsonld/AudioObject.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/ControlAction.json
+++ b/src/routes/helpers/jsonld/ControlAction.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/DataDownload.json
+++ b/src/routes/helpers/jsonld/DataDownload.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/Dataset.json
+++ b/src/routes/helpers/jsonld/Dataset.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/DefinedTerm.json
+++ b/src/routes/helpers/jsonld/DefinedTerm.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/DefinedTermSet.json
+++ b/src/routes/helpers/jsonld/DefinedTermSet.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/DeleteAction.json
+++ b/src/routes/helpers/jsonld/DeleteAction.json
@@ -13,7 +13,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/DigitalDocument.json
+++ b/src/routes/helpers/jsonld/DigitalDocument.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/DigitalDocumentPermission.json
+++ b/src/routes/helpers/jsonld/DigitalDocumentPermission.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/EntryPoint.json
+++ b/src/routes/helpers/jsonld/EntryPoint.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/Event.json
+++ b/src/routes/helpers/jsonld/Event.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/ImageObject.json
+++ b/src/routes/helpers/jsonld/ImageObject.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/Intangible.json
+++ b/src/routes/helpers/jsonld/Intangible.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/ItemList.json
+++ b/src/routes/helpers/jsonld/ItemList.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/ListItem.json
+++ b/src/routes/helpers/jsonld/ListItem.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/MediaObject.json
+++ b/src/routes/helpers/jsonld/MediaObject.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/MusicAlbum.json
+++ b/src/routes/helpers/jsonld/MusicAlbum.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/MusicComposition.json
+++ b/src/routes/helpers/jsonld/MusicComposition.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/MusicGroup.json
+++ b/src/routes/helpers/jsonld/MusicGroup.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/MusicPlaylist.json
+++ b/src/routes/helpers/jsonld/MusicPlaylist.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/MusicRecording.json
+++ b/src/routes/helpers/jsonld/MusicRecording.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/Occupation.json
+++ b/src/routes/helpers/jsonld/Occupation.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/Organization.json
+++ b/src/routes/helpers/jsonld/Organization.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/Person.json
+++ b/src/routes/helpers/jsonld/Person.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/Property.json
+++ b/src/routes/helpers/jsonld/Property.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/PropertyValue.json
+++ b/src/routes/helpers/jsonld/PropertyValue.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/PropertyValueSpecification.json
+++ b/src/routes/helpers/jsonld/PropertyValueSpecification.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/Rating.json
+++ b/src/routes/helpers/jsonld/Rating.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/ReplaceAction.json
+++ b/src/routes/helpers/jsonld/ReplaceAction.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/Review.json
+++ b/src/routes/helpers/jsonld/Review.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/SoftwareApplication.json
+++ b/src/routes/helpers/jsonld/SoftwareApplication.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/routes/helpers/jsonld/VideoObject.json
+++ b/src/routes/helpers/jsonld/VideoObject.json
@@ -67,7 +67,7 @@
       "https://schema.org/additionalType"
     ],
     "additionalProperty": [
-      "https://schema.org/additionalProperty"
+      "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     ],
     "alternateName": [
       "https://schema.org/alternateName"

--- a/src/schema/interface/ActionInterface.graphql
+++ b/src/schema/interface/ActionInterface.graphql
@@ -42,7 +42,7 @@ interface ActionInterface {
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/interface/CreativeWorkInterface.graphql
+++ b/src/schema/interface/CreativeWorkInterface.graphql
@@ -42,7 +42,7 @@ interface CreativeWorkInterface {
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/interface/LegalPersonInterface.graphql
+++ b/src/schema/interface/LegalPersonInterface.graphql
@@ -41,7 +41,7 @@ interface LegalPersonInterface {
     ### ThingInterface properties ###
     "https://schema.org/additionalType"
     additionalType: [String]
-    "https://schema.org/additionalProperty"
+    "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
     "https://schema.org/alternateName"
     alternateName: String

--- a/src/schema/interface/MediaObjectInterface.graphql
+++ b/src/schema/interface/MediaObjectInterface.graphql
@@ -42,7 +42,7 @@ interface MediaObjectInterface {
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/interface/OrganizationInterface.graphql
+++ b/src/schema/interface/OrganizationInterface.graphql
@@ -42,7 +42,7 @@ interface OrganizationInterface {
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/interface/PerformerInterface.graphql
+++ b/src/schema/interface/PerformerInterface.graphql
@@ -41,7 +41,7 @@ interface PerformerInterface {
     ### ThingInterface properties ###
     "https://schema.org/additionalType"
     additionalType: [String]
-    "https://schema.org/additionalProperty"
+    "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
     "https://schema.org/alternateName"
     alternateName: String

--- a/src/schema/interface/SearchableInterface.graphql
+++ b/src/schema/interface/SearchableInterface.graphql
@@ -5,7 +5,7 @@ interface SearchableInterface {
   identifier: ID
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/interface/ThingInterface.graphql
+++ b/src/schema/interface/ThingInterface.graphql
@@ -6,7 +6,7 @@ interface ThingInterface {
   identifier: ID
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/Action.graphql
+++ b/src/schema/type/Action.graphql
@@ -46,7 +46,7 @@ type Action implements ThingInterface & ActionInterface & ProvenanceEntityInterf
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/AddAction.graphql
+++ b/src/schema/type/AddAction.graphql
@@ -42,7 +42,7 @@ type AddAction implements ThingInterface & ActionInterface & ProvenanceEntityInt
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/Annotation.graphql
+++ b/src/schema/type/Annotation.graphql
@@ -71,7 +71,7 @@ type Annotation implements ThingInterface {
     ### ThingInterface properties ###
     "https://schema.org/additionalType"
     additionalType: [String]
-    "https://schema.org/additionalProperty"
+    "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
     "https://schema.org/alternateName"
     alternateName: String

--- a/src/schema/type/Article.graphql
+++ b/src/schema/type/Article.graphql
@@ -46,7 +46,7 @@ type Article implements SearchableInterface & ThingInterface & ProvenanceEntityI
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/Audience.graphql
+++ b/src/schema/type/Audience.graphql
@@ -41,7 +41,7 @@ type Audience implements ThingInterface {
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/AudioObject.graphql
+++ b/src/schema/type/AudioObject.graphql
@@ -46,7 +46,7 @@ type AudioObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/ControlAction.graphql
+++ b/src/schema/type/ControlAction.graphql
@@ -42,7 +42,7 @@ type ControlAction implements ThingInterface & ActionInterface & ProvenanceEntit
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/DataDownload.graphql
+++ b/src/schema/type/DataDownload.graphql
@@ -46,7 +46,7 @@ type DataDownload implements SearchableInterface & ThingInterface & ProvenanceEn
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/Dataset.graphql
+++ b/src/schema/type/Dataset.graphql
@@ -46,7 +46,7 @@ type Dataset implements SearchableInterface & ThingInterface & ProvenanceEntityI
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/DefinedTerm.graphql
+++ b/src/schema/type/DefinedTerm.graphql
@@ -42,7 +42,7 @@ type DefinedTerm implements ThingInterface {
     ### ThingInterface properties ###
     "https://schema.org/additionalType"
     additionalType: [String]
-    "https://schema.org/additionalProperty"
+    "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
     "https://schema.org/alternateName"
     alternateName: String

--- a/src/schema/type/DefinedTermSet.graphql
+++ b/src/schema/type/DefinedTermSet.graphql
@@ -42,7 +42,7 @@ type DefinedTermSet implements CreativeWorkInterface & ThingInterface {
     ### ThingInterface properties ###
     "https://schema.org/additionalType"
     additionalType: [String]
-    "https://schema.org/additionalProperty"
+    "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
     "https://schema.org/alternateName"
     alternateName: String

--- a/src/schema/type/DeleteAction.graphql
+++ b/src/schema/type/DeleteAction.graphql
@@ -6,7 +6,7 @@ type DeleteAction implements ThingInterface & ActionInterface & ProvenanceEntity
   identifier: ID @id
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/DigitalDocument.graphql
+++ b/src/schema/type/DigitalDocument.graphql
@@ -46,7 +46,7 @@ type DigitalDocument implements SearchableInterface & ThingInterface & Provenanc
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/DigitalDocumentPermission.graphql
+++ b/src/schema/type/DigitalDocumentPermission.graphql
@@ -42,7 +42,7 @@ type DigitalDocumentPermission implements ThingInterface & ProvenanceEntityInter
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/EntryPoint.graphql
+++ b/src/schema/type/EntryPoint.graphql
@@ -46,7 +46,7 @@ type EntryPoint implements ThingInterface & ProvenanceEntityInterface {
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/Event.graphql
+++ b/src/schema/type/Event.graphql
@@ -46,7 +46,7 @@ type Event implements SearchableInterface & ThingInterface & ProvenanceEntityInt
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/ImageObject.graphql
+++ b/src/schema/type/ImageObject.graphql
@@ -46,7 +46,7 @@ type ImageObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/Intangible.graphql
+++ b/src/schema/type/Intangible.graphql
@@ -44,7 +44,7 @@ type Intangible implements SearchableInterface & ThingInterface & ProvenanceEnti
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/ItemList.graphql
+++ b/src/schema/type/ItemList.graphql
@@ -42,7 +42,7 @@ type ItemList implements ThingInterface {
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/ListItem.graphql
+++ b/src/schema/type/ListItem.graphql
@@ -42,7 +42,7 @@ type ListItem implements ThingInterface {
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/MediaObject.graphql
+++ b/src/schema/type/MediaObject.graphql
@@ -46,7 +46,7 @@ type MediaObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/MusicAlbum.graphql
+++ b/src/schema/type/MusicAlbum.graphql
@@ -46,7 +46,7 @@ type MusicAlbum implements SearchableInterface & ThingInterface & ProvenanceEnti
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/MusicComposition.graphql
+++ b/src/schema/type/MusicComposition.graphql
@@ -46,7 +46,7 @@ type MusicComposition implements SearchableInterface & ThingInterface & Provenan
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/MusicGroup.graphql
+++ b/src/schema/type/MusicGroup.graphql
@@ -46,7 +46,7 @@ type MusicGroup implements SearchableInterface & ThingInterface & ProvenanceEnti
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/MusicPlaylist.graphql
+++ b/src/schema/type/MusicPlaylist.graphql
@@ -46,7 +46,7 @@ type MusicPlaylist implements SearchableInterface & ThingInterface & ProvenanceE
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/MusicRecording.graphql
+++ b/src/schema/type/MusicRecording.graphql
@@ -46,7 +46,7 @@ type MusicRecording implements SearchableInterface & ThingInterface & Provenance
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/Occupation.graphql
+++ b/src/schema/type/Occupation.graphql
@@ -42,7 +42,7 @@ type Occupation implements ThingInterface {
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/Organization.graphql
+++ b/src/schema/type/Organization.graphql
@@ -46,7 +46,7 @@ type Organization implements SearchableInterface & ThingInterface & ProvenanceEn
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/Person.graphql
+++ b/src/schema/type/Person.graphql
@@ -46,7 +46,7 @@ type Person implements SearchableInterface & ThingInterface & ProvenanceEntityIn
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/Property.graphql
+++ b/src/schema/type/Property.graphql
@@ -42,7 +42,7 @@ type Property implements ThingInterface {
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/PropertyValue.graphql
+++ b/src/schema/type/PropertyValue.graphql
@@ -42,7 +42,7 @@ type PropertyValue implements ThingInterface {
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/PropertyValueSpecification.graphql
+++ b/src/schema/type/PropertyValueSpecification.graphql
@@ -42,7 +42,7 @@ type PropertyValueSpecification implements ThingInterface {
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/Rating.graphql
+++ b/src/schema/type/Rating.graphql
@@ -42,7 +42,7 @@ type Rating implements ThingInterface & ProvenanceEntityInterface {
     ### ThingInterface properties ###
     "https://schema.org/additionalType"
     additionalType: [String]
-    "https://schema.org/additionalProperty"
+    "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
     additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
     "https://schema.org/alternateName"
     alternateName: String

--- a/src/schema/type/ReplaceAction.graphql
+++ b/src/schema/type/ReplaceAction.graphql
@@ -42,7 +42,7 @@ type ReplaceAction implements ThingInterface & ActionInterface & ProvenanceEntit
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/Review.graphql
+++ b/src/schema/type/Review.graphql
@@ -46,7 +46,7 @@ type Review implements SearchableInterface & ThingInterface & ProvenanceEntityIn
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/SoftwareApplication.graphql
+++ b/src/schema/type/SoftwareApplication.graphql
@@ -46,7 +46,7 @@ type SoftwareApplication implements SearchableInterface & ThingInterface & Prove
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String

--- a/src/schema/type/VideoObject.graphql
+++ b/src/schema/type/VideoObject.graphql
@@ -46,7 +46,7 @@ type VideoObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   ### ThingInterface properties ###
   "https://schema.org/additionalType"
   additionalType: [String]
-  "https://schema.org/additionalProperty"
+  "https://vocab.trompamusic.eu/vocab#AdditionalProperty"
   additionalProperty: [PropertyValue] @relation(name: "ADDITIONAL_PROPERTY", direction: OUT)
   "https://schema.org/alternateName"
   alternateName: String


### PR DESCRIPTION
the additionalProperty field is only valid on a few schema.org types,
not all types as we implemented here. Because the field is useful for us
in a few ways, define our own custom type for this field so that we
don't break schema.org rules.