### PR TITLE
feat(schema): Add rdau:P60537 (medium of performance) field

### DIFF
--- a/src/routes/helpers/jsonld/MediaObject.json
+++ b/src/routes/helpers/jsonld/MediaObject.json
@@ -4,6 +4,7 @@
       "https://schema.org/DigitalDocument"
     ]
   },
+  "relationalProperties": ["mediumOfPerformance"],
   "properties": {
     "identifier": [
       "http://purl.org/dc/terms/identifier",
@@ -287,6 +288,9 @@
     ],
     "width": [
       "https://schema.org/width"
+    ],
+    "mediumOfPerformance": [
+      "http://rdaregistry.info/Elements/u/P60537"
     ]
   }
 }

--- a/src/routes/helpers/jsonld/MusicComposition.json
+++ b/src/routes/helpers/jsonld/MusicComposition.json
@@ -4,6 +4,7 @@
       "https://schema.org/DigitalDocument"
     ]
   },
+  "relationalProperties": ["mediumOfPerformance"],
   "properties": {
     "identifier": [
       "http://purl.org/dc/terms/identifier",
@@ -323,6 +324,9 @@
     ],
     "recordedAs": [
       "https://schema.org/recordedAs"
+    ],
+    "mediumOfPerformance": [
+      "http://rdaregistry.info/Elements/u/P60537"
     ]
   }
 }

--- a/src/routes/helpers/transformers.js
+++ b/src/routes/helpers/transformers.js
@@ -8,7 +8,8 @@ const scopedContexts = {
   prov: 'http://www.w3.org/ns/prov#',
   skos: 'http://www.w3.org/2004/02/skos/core#',
   rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-  bib: 'https://bib.schema.org/'
+  bib: 'https://bib.schema.org/',
+  rdau: 'http://rdaregistry.info/Elements/u/'
 }
 
 /**
@@ -40,6 +41,7 @@ export const transformJsonLD = (type, data) => {
   if (!config) {
     throw new Error(`JSON LD not supported for type "${type}"`)
   }
+  const jsonldRelationalProperties = config.relationalProperties || []
 
   // Base JSON-LD document
   const jsonLdData = {
@@ -71,7 +73,7 @@ export const transformJsonLD = (type, data) => {
     }
 
     // Transform the value when it's a relational property
-    if (elementValue && schemaHelper.isRelationalProperty(property)) {
+    if (elementValue && (schemaHelper.isRelationalProperty(property) || jsonldRelationalProperties.includes(key))) {
       if (Array.isArray(elementValue)) {
         elementValue = elementValue.map(id => ({
           '@id': id

--- a/src/schema.js
+++ b/src/schema.js
@@ -6,7 +6,7 @@ import { resolvers } from './resolvers'
 import { authenticationFieldTransformer } from './transformers/authenticationFieldTransformer'
 import { subscriptionFieldTransformer } from './transformers/subscriptionFieldTransformer'
 import { createdUpdatedFieldTransformer } from './transformers/createdUpdatedFieldTransformer'
-import { additionalTypeFieldTransformer } from './transformers/additionalTypeFieldTransformer'
+import { validUrlFieldTransformer } from './transformers/validUrlFieldTransformer'
 import concatenate from './utils/concatenate'
 
 /*
@@ -51,6 +51,6 @@ export const schema = transformSchema(
     subscriptionFieldTransformer,
     authenticationFieldTransformer,
     createdUpdatedFieldTransformer,
-    additionalTypeFieldTransformer
+    validUrlFieldTransformer
   ]
 )

--- a/src/schema/type/MediaObject.graphql
+++ b/src/schema/type/MediaObject.graphql
@@ -206,4 +206,6 @@ type MediaObject implements SearchableInterface & ThingInterface & ProvenanceEnt
   uploadDate: _Neo4jDate
   "https://schema.org/width"
   width: Int
+  "A url to a skos:Concept representing the medium of performance of this MusicCompositation (e.g. instrumentation) "
+  mediumOfPerformance: [String]
 }

--- a/src/schema/type/MusicComposition.graphql
+++ b/src/schema/type/MusicComposition.graphql
@@ -233,4 +233,6 @@ type MusicComposition implements SearchableInterface & ThingInterface & Provenan
   musicalKey: String
   "https://schema.org/recordedAs"
   recordedAs: [MusicRecording] @relation(name: "RECORDED_AS", direction: OUT)
+  "A url to a skos:Concept representing the medium of performance of this MusicCompositation (e.g. instrumentation) "
+  mediumOfPerformance: [String]
 }


### PR DESCRIPTION
Fixes #42

Useful in MusicComposition and MediaObject to indicate instrumentation

As discussed in this issue, and in slack recently.

Need confirmation that this is correct in the context:
`"rdau": "http://rdaregistry.info/Elements/u/"`

We decided to use library of congress performance mediums, but this patch doesn't verify that the value of the field is a URL. If we want to add this we should modify `additionalTypeFieldTransformer` to be a generic is-a-url transformer checker.

Example mutation:
```graphql
mutation {
  CreateMusicComposition(
        name: "Prelude number 1 in some key"
        contributor: "https://musicbrainz.org"
        creator: "https://github.com/trompamusic/ce-data-import"
        source: "https://musicbrainz.org/work/some-uuid"
        format: "text/html"
    mediumOfPerformance:["http://id.loc.gov/authorities/performanceMediums/mp2013015550"]
) {
identifier
}
}
```

resulting json-ld output (edited)
```json
{
  "@context": [
    "https://schema.org/",
    {
      "dc": "http://purl.org/dc/terms/",
      "prov": "http://www.w3.org/ns/prov#",
      "skos": "http://www.w3.org/2004/02/skos/core#",
      "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
      "bib": "https://bib.schema.org/",
      "rdau": "http://rdaregistry.info/Elements/u/"
    }
  ],
  "@type": [
    "https://schema.org/MusicComposition"
  ],
  ... lots of items chopped here
  "rdau:P60537": [
    "http://id.loc.gov/authorities/performanceMediums/mp2013015550"
  ],
  "firstPerformance": null,
  "bitrate": null,
  "dc:language": null,
  "dc:source": "https://musicbrainz.org/work/some-uuid",
  ... lots of items chopped here
  "dc:identifier": "5a5f683f-ebe4-4ee0-975e-21170b44f6d6",
  "identifier": "5a5f683f-ebe4-4ee0-975e-21170b44f6d6",
  "image": null,
  "schema_publisher": [],
  "workExampleMediaObject": [],
  "dc:created": "2021-04-05T15:21:55.292000000Z",
  "dc:format": "text/html",
  ... lots of items chopped here
  "name": "Prelude number 1 in some key",
  ... lots of items chopped here
  "dc:contributor": "https://musicbrainz.org",
  "contributor": "https://musicbrainz.org",
  ... lots of items chopped here
}
```