### PR TITLE
Improve JSON-LD output

### DIFF
--- a/src/helpers/SchemaHelper.js
+++ b/src/helpers/SchemaHelper.js
@@ -31,11 +31,11 @@ class SchemaHelper {
    */
   findInterfaceImplementingTypes (interfaceName) {
     const implementations = this.findInterface(interfaceName)
-    if (!Array.isArray(implementations) || !implementations.length) {
+    if (!implementations.objects || !Array.isArray(implementations.objects) || !implementations.objects.length) {
       return null
     }
 
-    return implementations.map(implementation => { return implementation.toString() })
+    return implementations.objects.map(implementation => { return implementation.toString() })
   }
 
   /**
@@ -43,7 +43,7 @@ class SchemaHelper {
    * @returns {*|Array<GraphQLObjectType>}
    */
   findInterface (interfaceName) {
-    return this.schema.getImplementations(interfaceName)
+    return this.schema.getImplementations({name:interfaceName})
   }
 
   /**

--- a/src/routes/helpers/jsonld/ItemList.json
+++ b/src/routes/helpers/jsonld/ItemList.json
@@ -1,7 +1,9 @@
 {
   "head": {
     "@type": [
-      "https://schema.org/ItemList"
+      "https://schema.org/ItemList",
+      "http://www.w3.org/ns/ldp#Container",
+      "http://www.w3.org/ns/ldp#BasicContainer"
     ]
   },
   "properties": {
@@ -94,7 +96,8 @@
       "https://schema.org/url"
     ],
     "itemListElement": [
-      "https://schema.org/itemListElement"
+      "https://schema.org/itemListElement",
+      "http://www.w3.org/ns/ldp#contains"
     ],
     "itemListOrder": [
       "https://schema.org/itemListOrder"

--- a/src/routes/helpers/jsonld/MusicComposition.json
+++ b/src/routes/helpers/jsonld/MusicComposition.json
@@ -243,12 +243,6 @@
     "workExample": [
       "https://schema.org/workExample"
     ],
-    "workExampleMediaObject": [
-      "https://schema.org/workExample"
-    ],
-    "workExampleAudioObject": [
-      "https://schema.org/workExample"
-    ],
     "workTranslation": [
       "https://bib.schema.org/workTranslation"
     ],

--- a/src/routes/helpers/transformers.js
+++ b/src/routes/helpers/transformers.js
@@ -12,6 +12,8 @@ const scopedContexts = {
   trompa: 'https://vocab.trompamusic.eu/vocab#'
 }
 
+const defaultContext = 'https://schema.org'
+
 /**
  * Convert the given value to a Person type with either an URL or callSign value
  * @param value
@@ -53,7 +55,7 @@ export const transformJsonLD = (type, data) => {
   // Base JSON-LD document
   const jsonLdData = {
     '@context': [
-      'https://schema.org/',
+      defaultContext,
       scopedContexts
     ],
     ...config.head
@@ -116,13 +118,16 @@ export const transformJsonLD = (type, data) => {
         return
       }
 
-      if (uri.indexOf('https://schema.org') !== 0) {
+      if (uri.indexOf(defaultContext) !== 0) {
         // We have found an unknown namespace, log it to the console
         warning('Found new URI without context: ' + uri)
         return
       }
       // For {https://schema.org} we don't have to define a namespace (this is the default context)
-      jsonLdData[key] = elementValue
+      // in @context, we show the default context without a trailing /, but need to remove it
+      //  to get the correct type name, hence the + 1
+      const jsonLDKey = uri.substring(defaultContext.length + 1)
+      jsonLdData[jsonLDKey] = elementValue
     })
   })
 

--- a/src/routes/helpers/transformers.js
+++ b/src/routes/helpers/transformers.js
@@ -8,7 +8,8 @@ const scopedContexts = {
   prov: 'http://www.w3.org/ns/prov#',
   skos: 'http://www.w3.org/2004/02/skos/core#',
   rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-  bib: 'https://bib.schema.org/'
+  bib: 'https://bib.schema.org/',
+  trompa: 'https://vocab.trompamusic.eu/vocab#'
 }
 
 /**

--- a/src/routes/helpers/transformers.js
+++ b/src/routes/helpers/transformers.js
@@ -9,7 +9,8 @@ const scopedContexts = {
   skos: 'http://www.w3.org/2004/02/skos/core#',
   rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
   bib: 'https://bib.schema.org/',
-  trompa: 'https://vocab.trompamusic.eu/vocab#'
+  trompa: 'https://vocab.trompamusic.eu/vocab#',
+  ldp: 'http://www.w3.org/ns/ldp#'
 }
 
 const defaultContext = 'https://schema.org'

--- a/src/routes/helpers/transformers.js
+++ b/src/routes/helpers/transformers.js
@@ -30,6 +30,14 @@ const convertScalarToPerson = value => {
 }
 
 /**
+ * Check if a value is empty (null or empty array)
+ * @param value
+ */
+const isEmpty = value => {
+  return value === null || (Array.isArray(value) && value.length === 0)
+}
+
+/**
  * Transform document to a JSON-LD structured document
  * @param {string} type
  * @param {Object} data
@@ -114,7 +122,9 @@ export const transformJsonLD = (type, data) => {
       if (prefix) {
         const context = scopedContexts[prefix]
         const jsonLDKey = uri.substring(context.length)
-        jsonLdData[`${prefix}:${jsonLDKey}`] = elementValue
+        if (!isEmpty(elementValue)) {
+          jsonLdData[`${prefix}:${jsonLDKey}`] = elementValue
+        }
 
         return
       }
@@ -128,7 +138,9 @@ export const transformJsonLD = (type, data) => {
       // in @context, we show the default context without a trailing /, but need to remove it
       //  to get the correct type name, hence the + 1
       const jsonLDKey = uri.substring(defaultContext.length + 1)
-      jsonLdData[jsonLDKey] = elementValue
+      if (!isEmpty(elementValue)) {
+        jsonLdData[jsonLDKey] = elementValue
+      }
     })
   })
 

--- a/src/routes/helpers/transformers.js
+++ b/src/routes/helpers/transformers.js
@@ -36,8 +36,15 @@ export const transformJsonLD = (type, data) => {
   const schemaHelper = new SchemaHelper()
   const prefixes = Object.keys(scopedContexts)
 
-  const config = require(`./jsonld/${type}.json`)
-
+  let config
+  try {
+    config = require(`./jsonld/${type}.json`)
+  } catch (e) {
+    if (e.code !== 'MODULE_NOT_FOUND') {
+      throw e
+    }
+    config = null
+  }
   if (!config) {
     throw new Error(`JSON LD not supported for type "${type}"`)
   }


### PR DESCRIPTION
Fixes #178 - fix api call to get implementing types for an interface in graphql schema
Fixes #180 - correctly raise error if .json definition file cannot be found
Add json-ld context for vocab.trompamusic.eu
Fix json-ld output for schema.org fields to use the name of the field defined in the mapping instead of name in graphql schema
Fixes #175 - Make ItemLists also render as ldp:Container
Fixes #181 - don't render non-schema fields in json-ld output