### PR TITLE
feat(json-jd): Allow ItemList.item to be an external URL

### DIFF
--- a/src/routes/helpers/jsonld/ListItem.json
+++ b/src/routes/helpers/jsonld/ListItem.json
@@ -4,6 +4,7 @@
       "https://schema.org/ListItem"
     ]
   },
+  "relationalProperties": ["itemUrl"],
   "properties": {
     "identifier": [
       "http://purl.org/dc/terms/identifier",
@@ -94,6 +95,9 @@
       "https://schema.org/url"
     ],
     "item": [
+      "https://schema.org/item"
+    ],
+    "itemUrl": [
       "https://schema.org/item"
     ],
     "nextItem": [

--- a/src/schema/type/ListItem.graphql
+++ b/src/schema/type/ListItem.graphql
@@ -65,6 +65,8 @@ type ListItem implements ThingInterface {
   ### ListItem properties ###
   "https://schema.org/item"
   item: [ThingInterface] @relation(name: "ITEM", direction: OUT)
+  "If the item refers to an external URL, set it here"
+  itemUrl: [String]
   "https://schema.org/nextItem"
   nextItem: ListItem @relation(name: "NEXT_ITEM", direction: OUT)
   "https://schema.org/previousItem"


### PR DESCRIPTION
The CE model of ItemList allowed us to only link to existing items in the CE, but in linked data there's nothing stopping this from linking to an external URL. This allows us to make a list of things external to the CE.
This follows the same pattern that we use in the [annotation models](https://github.com/trompamusic/ce-api/blob/1e669bfcaab9fbc919b9d1c49abe546a27211b80/src/schema/type/Annotation.graphql#L93-L97) where we have separate fields for either a link to an item in the CE, or a text field linking to an external resource.

This PR requires #173 and #182 to be merged before it, and we also need to modify the `validUrlFieldTransformer` in #173 to also validate this field.

Items in the CE render like this:
```json
{
  "data": {
    "ListItem": [
      {
        "identifier": "bfbb7ff2-ffbd-4b3e-bee8-a7cb0ffd560b",
        "itemUrl": null,
        "item": [
          {
            "identifier": "7c338222-6c68-45ce-a1aa-f2a41a261520"
          }
        ]
      },
      {
        "identifier": "e4c988d6-1428-4985-a4c2-07d5a91740c3",
        "itemUrl": [
          "http://www.w3.org/ns/oa#commenting"
        ],
        "item": []
      }
    ]
  }
}
```
and as json-ld like this:
```json
{
  "@context": [
    "https://schema.org",
    {
      "dc": "http://purl.org/dc/terms/"
    }
  ],
  "@type": [
    "https://schema.org/ListItem"
  ],
  "dc:modified": "2021-04-10T22:48:12.443000000Z",
  "dc:identifier": "bfbb7ff2-ffbd-4b3e-bee8-a7cb0ffd560b",
  "identifier": "bfbb7ff2-ffbd-4b3e-bee8-a7cb0ffd560b",
  "item": [
    {
      "@id": "http://localhost:4000/7c338222-6c68-45ce-a1aa-f2a41a261520"
    }
  ],
  "dc:created": "2021-04-10T22:48:12.443000000Z",
  "name": "anitem"
}
```
or
```json

  "@context": [
    "https://schema.org",
    {
      "dc": "http://purl.org/dc/terms/"
    }
  ],
  "@type": [
    "https://schema.org/ListItem"
  ],
  "dc:modified": "2021-04-13T11:56:54.361000000Z",
  "dc:identifier": "e4c988d6-1428-4985-a4c2-07d5a91740c3",
  "identifier": "e4c988d6-1428-4985-a4c2-07d5a91740c3",
  "dc:created": "2021-04-13T11:56:54.361000000Z",
  "name": "some item",
  "item": [
    {
      "@id": "http://www.w3.org/ns/oa#commenting"
    }
  ]
}
```