### PR TITLE
fix(json-ld): Use a fully qualified url when setting skos:broader

### DIFF
--- a/src/routes/helpers/transformers.js
+++ b/src/routes/helpers/transformers.js
@@ -242,7 +242,7 @@ export function preprocessDefinedTermSet(data) {
   }
 
   if (data["broaderMotivation"]) {
-    data["broaderMotivation"] = "oa:" + data["broaderMotivation"];
+    data["broaderMotivation"] = "https://www.w3.org/ns/oa#" + data["broaderMotivation"];
   }
   return data
 }


### PR DESCRIPTION
We won't be sure that we have a definition for oa: in this context,
so be safe and just use the full url